### PR TITLE
Fix: blank header being displayed when using WPML

### DIFF
--- a/inc/compatibility/class-hfe-wpml-compatibility.php
+++ b/inc/compatibility/class-hfe-wpml-compatibility.php
@@ -32,7 +32,7 @@ class HFE_WPML_Compatibility {
 	 */
 	public static function instance() {
 		if ( ! isset( self::$_instance ) ) {
-			self::$_instance = new self;
+			self::$_instance = new self();
 		}
 
 		return self::$_instance;
@@ -56,7 +56,13 @@ class HFE_WPML_Compatibility {
 	 * @return Int $id  Post ID of the template being rendered, Passed through the `wpml_object_id` id.
 	 */
 	public function get_wpml_object( $id ) {
-		return apply_filters( 'wpml_object_id', $id );
+		$id = apply_filters( 'wpml_object_id', $id );
+
+		if ( null === $id ) {
+			$id = '';
+		}
+
+		return $id;
 	}
 
 }

--- a/inc/hfe-functions.php
+++ b/inc/hfe-functions.php
@@ -12,10 +12,10 @@
  * @return bool True if header is enabled. False if header is not enabled
  */
 function hfe_header_enabled() {
-	$header_id = Header_Footer_Elementor::get_settings( 'type_header', '' );
+	$header_id = Header_Footer_Elementor::get_settings( 'type_header', null );
 	$status    = false;
 
-	if ( '' !== $header_id ) {
+	if ( null !== $header_id ) {
 		$status = true;
 	}
 
@@ -29,10 +29,10 @@ function hfe_header_enabled() {
  * @return bool True if header is enabled. False if header is not enabled.
  */
 function hfe_footer_enabled() {
-	$footer_id = Header_Footer_Elementor::get_settings( 'type_footer', '' );
+	$footer_id = Header_Footer_Elementor::get_settings( 'type_footer', null );
 	$status    = false;
 
-	if ( '' !== $footer_id ) {
+	if ( null !== $footer_id ) {
 		$status = true;
 	}
 
@@ -46,9 +46,9 @@ function hfe_footer_enabled() {
  * @return (String|boolean) header id if it is set else returns false.
  */
 function get_hfe_header_id() {
-	$header_id = Header_Footer_Elementor::get_settings( 'type_header', '' );
+	$header_id = Header_Footer_Elementor::get_settings( 'type_header', null );
 
-	if ( '' === $header_id ) {
+	if ( null === $header_id ) {
 		$header_id = false;
 	}
 
@@ -62,9 +62,9 @@ function get_hfe_header_id() {
  * @return (String|boolean) header id if it is set else returns false.
  */
 function get_hfe_footer_id() {
-	$footer_id = Header_Footer_Elementor::get_settings( 'type_footer', '' );
+	$footer_id = Header_Footer_Elementor::get_settings( 'type_footer', null );
 
-	if ( '' === $footer_id ) {
+	if ( null === $footer_id ) {
 		$footer_id = false;
 	}
 

--- a/inc/hfe-functions.php
+++ b/inc/hfe-functions.php
@@ -12,10 +12,10 @@
  * @return bool True if header is enabled. False if header is not enabled
  */
 function hfe_header_enabled() {
-	$header_id = Header_Footer_Elementor::get_settings( 'type_header', null );
+	$header_id = Header_Footer_Elementor::get_settings( 'type_header', '' );
 	$status    = false;
 
-	if ( null !== $header_id ) {
+	if ( '' !== $header_id ) {
 		$status = true;
 	}
 
@@ -29,10 +29,10 @@ function hfe_header_enabled() {
  * @return bool True if header is enabled. False if header is not enabled.
  */
 function hfe_footer_enabled() {
-	$footer_id = Header_Footer_Elementor::get_settings( 'type_footer', null );
+	$footer_id = Header_Footer_Elementor::get_settings( 'type_footer', '' );
 	$status    = false;
 
-	if ( null !== $footer_id ) {
+	if ( '' !== $footer_id ) {
 		$status = true;
 	}
 
@@ -46,9 +46,9 @@ function hfe_footer_enabled() {
  * @return (String|boolean) header id if it is set else returns false.
  */
 function get_hfe_header_id() {
-	$header_id = Header_Footer_Elementor::get_settings( 'type_header', null );
+	$header_id = Header_Footer_Elementor::get_settings( 'type_header', '' );
 
-	if ( null === $header_id ) {
+	if ( '' === $header_id ) {
 		$header_id = false;
 	}
 
@@ -62,9 +62,9 @@ function get_hfe_header_id() {
  * @return (String|boolean) header id if it is set else returns false.
  */
 function get_hfe_footer_id() {
-	$footer_id = Header_Footer_Elementor::get_settings( 'type_footer', null );
+	$footer_id = Header_Footer_Elementor::get_settings( 'type_footer', '' );
 
-	if ( null === $footer_id ) {
+	if ( '' === $footer_id ) {
 		$footer_id = false;
 	}
 


### PR DESCRIPTION
This happens if only the footer is created and translated using WPML.