### PR TITLE
Bump z-index of header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,21 @@
+# ignore PHPStorm extra directories
+.idea/
+
+# OS specific files
 .DS_Store
-Thumbs.db
-wp-cli.local.yml
+
+# Leave node_modules from git
 node_modules/
+
+# sass cache
+.sass-cache
+
+# ignore PHPCS report files
+phpcs-summary.log
+phpcs-full.log
+
+# Org Package
 *.zip
-*.tar.gz
-package-lock.json
+
+# Ignore Composer's directories
+vendor/

--- a/assets/css/header-footer-elementor.css
+++ b/assets/css/header-footer-elementor.css
@@ -28,6 +28,6 @@
 
 /* Fix: Header hidden below the page content */
 .ehf-header #masthead {
-	z-index: 30;
+	z-index: 200;
     position: relative;
 }


### PR DESCRIPTION
Elementor adds z-index 99 on a few elements, sticky header needs to be over all the elements on page.

Fixes #150