### PR TITLE
Add support for all the WordPress themes

### DIFF
--- a/admin/class-hfe-admin.php
+++ b/admin/class-hfe-admin.php
@@ -146,7 +146,7 @@ class HFE_Admin {
 						<select name="ehf_template_type" id="ehf_template_type">
 							<option value="" <?php selected( $template_type, '' ); ?>><?php _e( 'Select Option', 'header-footer-elementor' ); ?></option>
 							<option value="type_header" <?php selected( $template_type, 'type_header' ); ?>><?php _e( 'Header', 'header-footer-elementor' ); ?></option>
-							<?php if ( 'astra' == get_template() ) { ?>
+							<?php if ( 'astra' == get_template() || ! current_theme_supports( 'header-footer-elementor' ) ) { ?>
 								<option value="type_before_footer" <?php selected( $template_type, 'type_before_footer' ); ?>><?php _e( 'Before Footer', 'header-footer-elementor' ); ?></option>
 							<?php } ?>
 							<option value="type_footer" <?php selected( $template_type, 'type_footer' ); ?>><?php _e( 'Footer', 'header-footer-elementor' ); ?></option>

--- a/assets/css/header-footer-elementor.css
+++ b/assets/css/header-footer-elementor.css
@@ -32,3 +32,9 @@
     position: relative;
 }
 
+.force-stretched-header {
+    width: 100vw;
+    position: relative;
+    margin-left: -50vw;
+    left: 50%;
+}

--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -76,6 +76,7 @@ class Header_Footer_Elementor {
 				require HFE_DIR . 'themes/oceanwp/class-hfe-oceanwp-compat.php';
 			} else {
 				add_action( 'init', array( $this, 'setup_unsupported_theme_notice' ) );
+				require HFE_DIR . 'themes/global-theme-fallback/class-global-theme-fallback.php';
 			}
 
 			// Scripts and styles.
@@ -245,6 +246,16 @@ class Header_Footer_Elementor {
 				$css_file = new \Elementor\Core\Files\CSS\Post( get_hfe_footer_id() );
 			} elseif ( class_exists( '\Elementor\Post_CSS_File' ) ) {
 				$css_file = new \Elementor\Post_CSS_File( get_hfe_footer_id() );
+			}
+
+			$css_file->enqueue();
+		}
+
+		if ( hfe_is_before_footer_enabled() ) {
+			if ( class_exists( '\Elementor\Core\Files\CSS\Post' ) ) {
+				$css_file = new \Elementor\Core\Files\CSS\Post( hfe_get_before_footer_id() );
+			} elseif ( class_exists( '\Elementor\Post_CSS_File' ) ) {
+				$css_file = new \Elementor\Post_CSS_File( hfe_get_before_footer_id() );
 			}
 
 			$css_file->enqueue();

--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -76,6 +76,7 @@ class Header_Footer_Elementor {
 				require HFE_DIR . 'themes/oceanwp/class-hfe-oceanwp-compat.php';
 			} else {
 				add_action( 'init', array( $this, 'setup_unsupported_theme_notice' ) );
+				add_action( 'get_header', [ $this, 'override_header' ] );
 				require HFE_DIR . 'themes/global-theme-fallback/class-global-theme-compatibility.php';
 			}
 
@@ -97,6 +98,21 @@ class Header_Footer_Elementor {
 			add_action( 'network_admin_notices', array( $this, 'elementor_not_available' ) );
 		}
 
+	}
+
+	
+	public function override_header() {
+		$templates = array();
+
+		$templates[] = 'header.php';
+
+		locate_template( $templates, true );
+
+		if ( ! did_action( 'wp_body_open' ) ) {
+			echo '<div class="force-stretched-header">';
+			do_action( 'hfe_fallback_header' );
+			echo '</div>';
+		}
 	}
 
 	/**

--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -76,7 +76,7 @@ class Header_Footer_Elementor {
 				require HFE_DIR . 'themes/oceanwp/class-hfe-oceanwp-compat.php';
 			} else {
 				add_action( 'init', array( $this, 'setup_unsupported_theme_notice' ) );
-				require HFE_DIR . 'themes/global-theme-fallback/class-global-theme-fallback.php';
+				require HFE_DIR . 'themes/global-theme-fallback/class-global-theme-compatibility.php';
 			}
 
 			// Scripts and styles.

--- a/themes/global-theme-fallback/class-global-theme-compatibility.php
+++ b/themes/global-theme-fallback/class-global-theme-compatibility.php
@@ -36,7 +36,7 @@ class Global_Theme_Compatibility {
 			add_action( 'wp_footer', array( 'Header_Footer_Elementor', 'get_footer_content' ), 50 );
 		}
 
-    }
+	}
 
 }
 

--- a/themes/global-theme-fallback/class-global-theme-compatibility.php
+++ b/themes/global-theme-fallback/class-global-theme-compatibility.php
@@ -8,7 +8,7 @@
 namespace HFE\Themes;
 
 /**
- * Genesis theme compatibility.
+ * Global theme compatibility.
  */
 class Global_Theme_Compatibility {
 

--- a/themes/global-theme-fallback/class-global-theme-compatibility.php
+++ b/themes/global-theme-fallback/class-global-theme-compatibility.php
@@ -26,6 +26,7 @@ class Global_Theme_Compatibility {
 
 		if ( hfe_header_enabled() ) {
 			add_action( 'wp_body_open', array( 'Header_Footer_Elementor', 'get_header_content' ) );
+			add_action( 'hfe_fallback_header', array( 'Header_Footer_Elementor', 'get_header_content' ) );
 		}
 
 		if ( hfe_is_before_footer_enabled() ) {

--- a/themes/global-theme-fallback/class-global-theme-fallback.php
+++ b/themes/global-theme-fallback/class-global-theme-fallback.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Support all themes.
+ *
+ * @package header-footer-elementor
+ */
+
+namespace HFE\Themes;
+
+/**
+ * Genesis theme compatibility.
+ */
+class Global_Theme_Compatibility {
+
+	/**
+	 *  Initiator
+	 */
+	public function __construct() {
+		add_action( 'wp', array( $this, 'hooks' ) );
+	}
+
+	/**
+	 * Run all the Actions / Filters.
+	 */
+	public function hooks() {
+
+		if ( hfe_header_enabled() ) {
+			add_action( 'wp_body_open', array( 'Header_Footer_Elementor', 'get_header_content' ) );
+		}
+
+		if ( hfe_is_before_footer_enabled() ) {
+			add_action( 'wp_footer', array( 'Header_Footer_Elementor', 'get_before_footer_content' ), 20 );
+		}
+
+		if ( hfe_footer_enabled() ) {
+			add_action( 'wp_footer', array( 'Header_Footer_Elementor', 'get_footer_content' ), 50 );
+		}
+
+    }
+
+}
+
+new Global_Theme_Compatibility();


### PR DESCRIPTION
- A theme should have action `wp_body_open` to display header
- Footer and below footer can be displayed in all the themes

Fixes #178
Fixes #165 
Fixes #157
Fixes #153