### PR TITLE
Initialize class without `plugins_loaded` hook to fix the post type …

### DIFF
--- a/header-footer-elementor.php
+++ b/header-footer-elementor.php
@@ -25,8 +25,4 @@ require_once HFE_DIR . '/inc/class-header-footer-elementor.php';
 /**
  * Load the Plugin Class.
  */
-function hfe_init() {
-	new Header_Footer_Elementor();
-}
-
-add_action( 'plugins_loaded', 'hfe_init' );
+new Header_Footer_Elementor();


### PR DESCRIPTION
Initialize class without `plugins_loaded` hook to fix the post type not exist issue while importing the Astra Sites with WP CLI command.