### PR TITLE
Version 1.2.0

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -41,12 +41,80 @@ module.exports = function( grunt ) {
 				}
 			}
 		},
+
+		bumpup: {
+			options: {
+				updateProps: {
+					pkg: 'package.json'
+				}
+			},
+			file: 'package.json'
+		},
+
+		replace: {
+			plugin_main: {
+				src: ['header-footer-elementor.php'],
+				overwrite: true,
+				replacements: [
+					{
+						from: /Version: \bv?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[\da-z-A-Z-]+(?:\.[\da-z-A-Z-]+)*)?(?:\+[\da-z-A-Z-]+(?:\.[\da-z-A-Z-]+)*)?\b/g,
+						to: 'Version: <%= pkg.version %>'
+					}
+				]
+			},
+
+			plugin_const: {
+				src: ['header-footer-elementor.php'],
+				overwrite: true,
+				replacements: [
+					{
+						from: /HFE_VER', '.*?'/g,
+						to: 'HFE_VER\', \'<%= pkg.version %>\''
+					}
+				]
+			},
+
+			plugin_function_comment: {
+				src: [
+					'*.php',
+					'**/*.php',
+					'!node_modules/**',
+					'!php-tests/**',
+					'!bin/**',
+					'!admin/bsf-core/**'
+				],
+				overwrite: true,
+				replacements: [
+					{
+						from: 'x.x.x',
+						to: '<%=pkg.version %>'
+					}
+				]
+			}
+		}
+
 	} );
 
 	grunt.loadNpmTasks( 'grunt-wp-i18n' );
 	grunt.loadNpmTasks( 'grunt-wp-readme-to-markdown' );
+	grunt.loadNpmTasks( 'grunt-bumpup' );
+	grunt.loadNpmTasks( 'grunt-text-replace' );
+	
 	grunt.registerTask( 'i18n', ['addtextdomain', 'makepot'] );
 	grunt.registerTask( 'readme', ['wp_readme_to_markdown'] );
+
+	// Bump Version - `grunt version-bump --ver=<version-number>`
+    grunt.registerTask('version-bump', function (ver) {
+
+        var newVersion = grunt.option('ver');
+
+        if (newVersion) {
+            newVersion = newVersion ? newVersion : 'patch';
+
+            grunt.task.run('bumpup:' + newVersion);
+            grunt.task.run('replace');
+        }
+    });
 
 	grunt.util.linefeed = '\n';
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,13 +52,24 @@ module.exports = function( grunt ) {
 		},
 
 		replace: {
+			plugin_readme: {
+				src: ['readme.txt'],
+				overwrite: true,
+				replacements: [
+					{
+						from: /Stable tag:\ ((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:[1-9]\d*|[\da-z-]*[a-z-][\da-z-]*)(?:\.(?:[1-9]\d*|[\da-z-]*[a-z-][\da-z-]*))*)?(?:\+[\da-z-]+(?:\.[\da-z-]+)*)?)/g,
+						to: 'Stable tag: <%= pkg.version %>'
+					}
+				]
+			},
+
 			plugin_main: {
 				src: ['header-footer-elementor.php'],
 				overwrite: true,
 				replacements: [
 					{
-						from: /Version: \bv?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[\da-z-A-Z-]+(?:\.[\da-z-A-Z-]+)*)?(?:\+[\da-z-A-Z-]+(?:\.[\da-z-A-Z-]+)*)?\b/g,
-						to: 'Version: <%= pkg.version %>'
+						from: /Version:[\t\s]+((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:[1-9]\d*|[\da-z-]*[a-z-][\da-z-]*)(?:\.(?:[1-9]\d*|[\da-z-]*[a-z-][\da-z-]*))*)?(?:\+[\da-z-]+(?:\.[\da-z-]+)*)?)/g,
+						to: 'Version:		<%= pkg.version %>'
 					}
 				]
 			},

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -69,7 +69,7 @@ module.exports = function( grunt ) {
 				replacements: [
 					{
 						from: /Version:[\t\s]+((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:[1-9]\d*|[\da-z-]*[a-z-][\da-z-]*)(?:\.(?:[1-9]\d*|[\da-z-]*[a-z-][\da-z-]*))*)?(?:\+[\da-z-]+(?:\.[\da-z-]+)*)?)/g,
-						to: 'Version:		<%= pkg.version %>'
+						to: 'Version: <%= pkg.version %>'
 					}
 				]
 			},

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Requires at least:** 4.4  
 **Requires PHP:** 5.4  
 **Tested up to:** 5.3  
-**Stable tag:** 1.1.4  
+**Stable tag:** 1.2.0-beta.1  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -109,8 +109,12 @@ If the above is nnot possible, You can also add support for the plugin from your
 ## Changelog ##
 
 ### 1.2.0 (Unreleased) ###
-- Improvement: Allow before footer to work on Elementor Canvas Template when not usina Astra Theme.
+- New: Support all the themes, Includes two separate fallback methods so that you can create custom headers and footers for any theme.
+- New: Added target rule engine which allows you to have different headers/footer for different pages.
+- New: Added Retina Image Elementor widget which can be used as a Site Logo.
 - New: Added Copyright widget and Shortcode for current year & site title.
+- Improvement: Allow before footer to work on Elementor Canvas Template when not usina Astra Theme.
+- Improvement: Added support of `Before Footer` action for all the themes.
 
 ### 1.1.4 ###
 - Fix: Flush permalinks on plugin update to Elementor error when trying to edit the Header/Footer.

--- a/README.md
+++ b/README.md
@@ -110,10 +110,10 @@ If the above is nnot possible, You can also add support for the plugin from your
 
 ### 1.2.0 (Unreleased) ###
 - New: Support all the themes, Includes two separate fallback methods so that you can create custom headers and footers for any theme.
-- New: Added target rule engine which allows you to have different headers/footer for different pages.
-- New: Added Retina Image Elementor widget which can be used as a Site Logo.
+- New: Added target rule engine, which allows you to have different headers/footers for different pages.
+- New: Added Retina Image Elementor widget, which can be used as a Site Logo.
 - New: Added Copyright widget and Shortcode for current year & site title.
-- Improvement: Allow before footer to work on Elementor Canvas Template when not usina Astra Theme.
+- Improvement: Allow before footer to work on Elementor Canvas Template when not using Astra Theme.
 - Improvement: Added support of `Before Footer` action for all the themes.
 
 ### 1.1.4 ###

--- a/header-footer-elementor.php
+++ b/header-footer-elementor.php
@@ -7,12 +7,12 @@
  * Author URI:  https://www.brainstormforce.com/
  * Text Domain: header-footer-elementor
  * Domain Path: /languages
- * Version:     1.2.0-beta.1
+ * Version: 1.2.0-beta.2
  *
  * @package         header-footer-elementor
  */
 
-define( 'HFE_VER', '1.2.0-beta.1' );
+define( 'HFE_VER', '1.2.0-beta.2' );
 define( 'HFE_DIR', plugin_dir_path( __FILE__ ) );
 define( 'HFE_URL', plugins_url( '/', __FILE__ ) );
 define( 'HFE_PATH', plugin_basename( __FILE__ ) );

--- a/header-footer-elementor.php
+++ b/header-footer-elementor.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Plugin Name:     Elementor - Header, Footer & Blocks
- * Plugin URI:      https://github.com/Nikschavan/header-footer-elementor
- * Description:     Create Header and Footer for your site using Elementor Page Builder.
- * Author:          Brainstorm Force, Nikhil Chavan
- * Author URI:      https://www.brainstormforce.com/
- * Text Domain:     header-footer-elementor
- * Domain Path:     /languages
- * Version:         1.1.4
+ * Plugin Name:	Elementor - Header, Footer & Blocks
+ * Plugin URI:	https://github.com/Nikschavan/header-footer-elementor
+ * Description:	Create Header and Footer for your site using Elementor Page Builder.
+ * Author:		Brainstorm Force, Nikhil Chavan
+ * Author URI:	https://www.brainstormforce.com/
+ * Text Domain:	header-footer-elementor
+ * Domain Path:	/languages
+ * Version:		1.2.0-beta.1
  *
  * @package         header-footer-elementor
  */

--- a/header-footer-elementor.php
+++ b/header-footer-elementor.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Plugin Name:	Elementor - Header, Footer & Blocks
- * Plugin URI:	https://github.com/Nikschavan/header-footer-elementor
- * Description:	Create Header and Footer for your site using Elementor Page Builder.
- * Author:		Brainstorm Force, Nikhil Chavan
- * Author URI:	https://www.brainstormforce.com/
- * Text Domain:	header-footer-elementor
- * Domain Path:	/languages
- * Version:		1.2.0-beta.1
+ * Plugin Name: Elementor - Header, Footer & Blocks
+ * Plugin URI:  https://github.com/Nikschavan/header-footer-elementor
+ * Description: Create Header and Footer for your site using Elementor Page Builder.
+ * Author:      Brainstorm Force, Nikhil Chavan
+ * Author URI:  https://www.brainstormforce.com/
+ * Text Domain: header-footer-elementor
+ * Domain Path: /languages
+ * Version:     1.2.0-beta.1
  *
  * @package         header-footer-elementor
  */

--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -106,7 +106,7 @@ class Header_Footer_Elementor {
 	/**
 	 * Register Astra Notices.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 *
 	 * @return void
 	 */
@@ -159,7 +159,7 @@ class Header_Footer_Elementor {
 	/**
 	 * Enqueue CSS for the Rating Notice.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 * @return void
 	 */
 	public function rating_notice_css() {

--- a/inc/class-hfe-update.php
+++ b/inc/class-hfe-update.php
@@ -59,7 +59,7 @@ if ( ! class_exists( 'HFE_Update' ) ) {
 
 			$db_version = get_option( $this->db_option_key, false );
 
-			if ( version_compare( $db_version, '1.2.0-beta.1', '<' ) ) {
+			if ( version_compare( $db_version, '1.2.0-beta.2', '<' ) ) {
 				$this->setup_default_terget_rules();
 			}
 

--- a/inc/class-hfe-update.php
+++ b/inc/class-hfe-update.php
@@ -74,7 +74,7 @@ if ( ! class_exists( 'HFE_Update' ) ) {
 		/**
 		 * Set default target rules for header, footer, before footers being used before target rules were added to the plugin.
 		 *
-		 * @since x.x.x
+		 * @since 1.2.0-beta.1
 		 * @return void
 		 */
 		private function setup_default_terget_rules() {

--- a/inc/lib/target-rule/class-astra-target-rules-fields.php
+++ b/inc/lib/target-rule/class-astra-target-rules-fields.php
@@ -124,30 +124,30 @@ class Astra_Target_Rules_Fields {
 		$post_types = apply_filters( 'astra_location_rule_post_types', array_merge( $post_types, $custom_post_type ) );
 
 		$special_pages = array(
-			'special-404'    => __( '404 Page', 'astra-addon' ),
-			'special-search' => __( 'Search Page', 'astra-addon' ),
-			'special-blog'   => __( 'Blog / Posts Page', 'astra-addon' ),
-			'special-front'  => __( 'Front Page', 'astra-addon' ),
-			'special-date'   => __( 'Date Archive', 'astra-addon' ),
-			'special-author' => __( 'Author Archive', 'astra-addon' ),
+			'special-404'    => __( '404 Page', 'header-footer-elementor' ),
+			'special-search' => __( 'Search Page', 'header-footer-elementor' ),
+			'special-blog'   => __( 'Blog / Posts Page', 'header-footer-elementor' ),
+			'special-front'  => __( 'Front Page', 'header-footer-elementor' ),
+			'special-date'   => __( 'Date Archive', 'header-footer-elementor' ),
+			'special-author' => __( 'Author Archive', 'header-footer-elementor' ),
 		);
 
 		if ( class_exists( 'WooCommerce' ) ) {
-			$special_pages['special-woo-shop'] = __( 'WooCommerce Shop Page', 'astra-addon' );
+			$special_pages['special-woo-shop'] = __( 'WooCommerce Shop Page', 'header-footer-elementor' );
 		}
 
 		$selection_options = array(
 			'basic'         => array(
-				'label' => __( 'Basic', 'astra-addon' ),
+				'label' => __( 'Basic', 'header-footer-elementor' ),
 				'value' => array(
-					'basic-global'    => __( 'Entire Website', 'astra-addon' ),
-					'basic-singulars' => __( 'All Singulars', 'astra-addon' ),
-					'basic-archives'  => __( 'All Archives', 'astra-addon' ),
+					'basic-global'    => __( 'Entire Website', 'header-footer-elementor' ),
+					'basic-singulars' => __( 'All Singulars', 'header-footer-elementor' ),
+					'basic-archives'  => __( 'All Archives', 'header-footer-elementor' ),
 				),
 			),
 
 			'special-pages' => array(
-				'label' => __( 'Special Pages', 'astra-addon' ),
+				'label' => __( 'Special Pages', 'header-footer-elementor' ),
 				'value' => $special_pages,
 			),
 		);
@@ -188,9 +188,9 @@ class Astra_Target_Rules_Fields {
 		}
 
 		$selection_options['specific-target'] = array(
-			'label' => __( 'Specific Target', 'astra-addon' ),
+			'label' => __( 'Specific Target', 'header-footer-elementor' ),
 			'value' => array(
-				'specifics' => __( 'Specific Pages / Posts / Taxanomies, etc.', 'astra-addon' ),
+				'specifics' => __( 'Specific Pages / Posts / Taxanomies, etc.', 'header-footer-elementor' ),
 			),
 		);
 
@@ -210,16 +210,16 @@ class Astra_Target_Rules_Fields {
 	public static function get_user_selections() {
 		$selection_options = array(
 			'basic'    => array(
-				'label' => __( 'Basic', 'astra-addon' ),
+				'label' => __( 'Basic', 'header-footer-elementor' ),
 				'value' => array(
-					'all'        => __( 'All', 'astra-addon' ),
-					'logged-in'  => __( 'Logged In', 'astra-addon' ),
-					'logged-out' => __( 'Logged Out', 'astra-addon' ),
+					'all'        => __( 'All', 'header-footer-elementor' ),
+					'logged-in'  => __( 'Logged In', 'header-footer-elementor' ),
+					'logged-out' => __( 'Logged Out', 'header-footer-elementor' ),
 				),
 			),
 
 			'advanced' => array(
-				'label' => __( 'Advanced', 'astra-addon' ),
+				'label' => __( 'Advanced', 'header-footer-elementor' ),
 				'value' => array(),
 			),
 		);
@@ -616,18 +616,18 @@ class Astra_Target_Rules_Fields {
 		 */
 		$localize_vars = array(
 			'ast_lang'      => $ast_lang,
-			'please_enter'  => __( 'Please enter', 'astra-addon' ),
-			'please_delete' => __( 'Please delete', 'astra-addon' ),
-			'more_char'     => __( 'or more characters', 'astra-addon' ),
-			'character'     => __( 'character', 'astra-addon' ),
-			'loading'       => __( 'Loading more results…', 'astra-addon' ),
-			'only_select'   => __( 'You can only select', 'astra-addon' ),
-			'item'          => __( 'item', 'astra-addon' ),
-			'char_s'        => __( 's', 'astra-addon' ),
-			'no_result'     => __( 'No results found', 'astra-addon' ),
-			'searching'     => __( 'Searching…', 'astra-addon' ),
-			'not_loader'    => __( 'The results could not be loaded.', 'astra-addon' ),
-			'search'        => __( 'Search pages / post / categories', 'astra-addon' ),
+			'please_enter'  => __( 'Please enter', 'header-footer-elementor' ),
+			'please_delete' => __( 'Please delete', 'header-footer-elementor' ),
+			'more_char'     => __( 'or more characters', 'header-footer-elementor' ),
+			'character'     => __( 'character', 'header-footer-elementor' ),
+			'loading'       => __( 'Loading more results…', 'header-footer-elementor' ),
+			'only_select'   => __( 'You can only select', 'header-footer-elementor' ),
+			'item'          => __( 'item', 'header-footer-elementor' ),
+			'char_s'        => __( 's', 'header-footer-elementor' ),
+			'no_result'     => __( 'No results found', 'header-footer-elementor' ),
+			'searching'     => __( 'Searching…', 'header-footer-elementor' ),
+			'not_loader'    => __( 'The results could not be loaded.', 'header-footer-elementor' ),
+			'search'        => __( 'Search pages / post / categories', 'header-footer-elementor' ),
 		);
 		wp_localize_script( 'astra-select2', 'astRules', $localize_vars );
 	}
@@ -645,7 +645,7 @@ class Astra_Target_Rules_Fields {
 		$type           = isset( $settings['type'] ) ? $settings['type'] : 'target_rule';
 		$class          = isset( $settings['class'] ) ? $settings['class'] : '';
 		$rule_type      = isset( $settings['rule_type'] ) ? $settings['rule_type'] : 'target_rule';
-		$add_rule_label = isset( $settings['add_rule_label'] ) ? $settings['add_rule_label'] : __( 'Add Rule', 'astra-addon' );
+		$add_rule_label = isset( $settings['add_rule_label'] ) ? $settings['add_rule_label'] : __( 'Add Rule', 'header-footer-elementor' );
 		$saved_values   = $value;
 		$output         = '';
 
@@ -661,7 +661,7 @@ class Astra_Target_Rules_Fields {
 		/* Condition Selection */
 		$output .= '<div class="target_rule-condition-wrap" >';
 		$output .= '<select name="' . esc_attr( $input_name ) . '[rule][{{data.id}}]" class="target_rule-condition form-control ast-input">';
-		$output .= '<option value="">' . __( 'Select', 'astra-addon' ) . '</option>';
+		$output .= '<option value="">' . __( 'Select', 'header-footer-elementor' ) . '</option>';
 
 		foreach ( $selection_options as $group => $group_data ) {
 			$output .= '<optgroup label="' . $group_data['label'] . '">';
@@ -711,12 +711,12 @@ class Astra_Target_Rules_Fields {
 		$post_option = array();
 
 		/* translators: %s post label */
-		$all_posts                          = sprintf( __( 'All %s', 'astra-addon' ), $post_label );
+		$all_posts                          = sprintf( __( 'All %s', 'header-footer-elementor' ), $post_label );
 		$post_option[ $post_name . '|all' ] = $all_posts;
 
 		if ( 'pages' != $post_key ) {
 			/* translators: %s post label */
-			$all_archive                                = sprintf( __( 'All %s Archive', 'astra-addon' ), $post_label );
+			$all_archive                                = sprintf( __( 'All %s Archive', 'header-footer-elementor' ), $post_label );
 			$post_option[ $post_name . '|all|archive' ] = $all_archive;
 		}
 
@@ -725,7 +725,7 @@ class Astra_Target_Rules_Fields {
 			$tax_name  = $taxonomy->name;
 
 			/* translators: %s taxonomy label */
-			$tax_archive = sprintf( __( 'All %s Archive', 'astra-addon' ), $tax_label );
+			$tax_archive = sprintf( __( 'All %s Archive', 'header-footer-elementor' ), $tax_label );
 
 			$post_option[ $post_name . '|all|taxarchive|' . $tax_name ] = $tax_archive;
 		}
@@ -766,7 +766,7 @@ class Astra_Target_Rules_Fields {
 			$output .= '<span class="target_rule-condition-delete dashicons dashicons-dismiss"></span>';
 			$output .= '<div class="target_rule-condition-wrap" >';
 			$output .= '<select name="' . esc_attr( $input_name ) . '[rule][' . $index . ']" class="target_rule-condition form-control ast-input">';
-			$output .= '<option value="">' . __( 'Select', 'astra-addon' ) . '</option>';
+			$output .= '<option value="">' . __( 'Select', 'header-footer-elementor' ) . '</option>';
 
 			foreach ( $selection_options as $group => $group_data ) {
 				$output .= '<optgroup label="' . $group_data['label'] . '">';
@@ -837,7 +837,7 @@ class Astra_Target_Rules_Fields {
 		if ( 'display' == $type ) {
 			/* Add new rule */
 			$output .= '<div class="target_rule-add-exclusion-rule">';
-			$output .= '<a href="#" class="button">' . __( 'Add Exclusion Rule', 'astra-addon' ) . '</a>';
+			$output .= '<a href="#" class="button">' . __( 'Add Exclusion Rule', 'header-footer-elementor' ) . '</a>';
 			$output .= '</div>';
 		}
 
@@ -1054,7 +1054,7 @@ class Astra_Target_Rules_Fields {
 		$type           = isset( $settings['type'] ) ? $settings['type'] : 'target_rule';
 		$class          = isset( $settings['class'] ) ? $settings['class'] : '';
 		$rule_type      = isset( $settings['rule_type'] ) ? $settings['rule_type'] : 'target_rule';
-		$add_rule_label = isset( $settings['add_rule_label'] ) ? $settings['add_rule_label'] : __( 'Add Rule', 'astra-addon' );
+		$add_rule_label = isset( $settings['add_rule_label'] ) ? $settings['add_rule_label'] : __( 'Add Rule', 'header-footer-elementor' );
 		$saved_values   = $value;
 		$output         = '';
 
@@ -1070,7 +1070,7 @@ class Astra_Target_Rules_Fields {
 				/* Condition Selection */
 				$output     .= '<div class="user_role-condition-wrap" >';
 					$output .= '<select name="' . esc_attr( $input_name ) . '[{{data.id}}]" class="user_role-condition form-control ast-input">';
-					$output .= '<option value="">' . __( 'Select', 'astra-addon' ) . '</option>';
+					$output .= '<option value="">' . __( 'Select', 'header-footer-elementor' ) . '</option>';
 
 		foreach ( $selection_options as $group => $group_data ) {
 			$output .= '<optgroup label="' . $group_data['label'] . '">';
@@ -1100,7 +1100,7 @@ class Astra_Target_Rules_Fields {
 				/* Condition Selection */
 				$output     .= '<div class="user_role-condition-wrap" >';
 					$output .= '<select name="' . esc_attr( $input_name ) . '[' . $index . ']" class="user_role-condition form-control ast-input">';
-					$output .= '<option value="">' . __( 'Select', 'astra-addon' ) . '</option>';
+					$output .= '<option value="">' . __( 'Select', 'header-footer-elementor' ) . '</option>';
 
 			foreach ( $selection_options as $group => $group_data ) {
 				$output .= '<optgroup label="' . $group_data['label'] . '">';
@@ -1491,7 +1491,7 @@ class Astra_Target_Rules_Fields {
 					$rule_set_titles = '<strong>' . implode( ',', $already_set_rule ) . '</strong>';
 
 					/* translators: %s post title. */
-					$notice = sprintf( __( 'The same display setting is already exist in %s post/s.', 'astra-addon' ), $rule_set_titles );
+					$notice = sprintf( __( 'The same display setting is already exist in %s post/s.', 'header-footer-elementor' ), $rule_set_titles );
 
 					echo '<div class="error">';
 					echo '<p>' . $notice . '</p>';
@@ -1550,7 +1550,7 @@ class Astra_Target_Rules_Fields {
 
 		if ( ! empty( $all_headers ) ) {
 			$headers = array(
-				'' => __( 'Select', 'astra-addon' ),
+				'' => __( 'Select', 'header-footer-elementor' ),
 			);
 
 			foreach ( $all_headers as $i => $data ) {

--- a/inc/widgets-manager/class-widgets-loader.php
+++ b/inc/widgets-manager/class-widgets-loader.php
@@ -6,7 +6,7 @@
  * @author      HFE
  * @copyright   Copyright (c) 2018, HFE
  * @link        http://brainstormforce.com/
- * @since       HFE x.x.x
+ * @since       HFE 1.2.0
  */
 
 namespace HFE\WidgetsManager;
@@ -23,7 +23,7 @@ class Widgets_Loader {
 	/**
 	 * Instance of Widgets_Loader.
 	 *
-	 * @since  x.x.x
+	 * @since  1.2.0
 	 * @var null
 	 */
 	private static $_instance = null;
@@ -31,7 +31,7 @@ class Widgets_Loader {
 	/**
 	 * Get instance of Widgets_Loader
 	 *
-	 * @since  x.x.x
+	 * @since  1.2.0
 	 * @return Widgets_Loader
 	 */
 	public static function instance() {
@@ -45,7 +45,7 @@ class Widgets_Loader {
 	/**
 	 * Setup actions and filters.
 	 *
-	 * @since  x.x.x
+	 * @since  1.2.0
 	 */
 	private function __construct() {
 		// Register widgets.
@@ -61,7 +61,7 @@ class Widgets_Loader {
 	 *
 	 * Load widgets files
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 * @access public
 	 */
 	public function include_widgets_files() {
@@ -75,7 +75,7 @@ class Widgets_Loader {
 	 *
 	 * @param array $mimes which return mime type.
 	 *
-	 * @since  x.x.x
+	 * @since  1.2.0
 	 * @return $mimes.
 	 */
 	public function hfe_svg_mime_types( $mimes ) {
@@ -90,7 +90,7 @@ class Widgets_Loader {
 	 *
 	 * Register new Elementor widgets.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 * @access public
 	 */
 	public function register_widgets() {

--- a/inc/widgets-manager/widgets/class-copyright-shortcode.php
+++ b/inc/widgets-manager/widgets/class-copyright-shortcode.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Helper class for the Copyright.
  *
- * @since x.x.x
+ * @since 1.2.0
  */
 class Copyright_Shortcode {
 

--- a/inc/widgets-manager/widgets/class-copyright.php
+++ b/inc/widgets-manager/widgets/class-copyright.php
@@ -24,14 +24,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * Elementor widget for copyright.
  *
- * @since x.x.x
+ * @since 1.2.0
  */
 class Copyright extends Widget_Base {
 
 	/**
 	 * Retrieve the widget name.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 *
 	 * @access public
 	 *
@@ -43,7 +43,7 @@ class Copyright extends Widget_Base {
 	/**
 	 * Retrieve the widget title.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 *
 	 * @access public
 	 *
@@ -55,7 +55,7 @@ class Copyright extends Widget_Base {
 	/**
 	 * Retrieve the widget icon.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 *
 	 * @access public
 	 *
@@ -72,7 +72,7 @@ class Copyright extends Widget_Base {
 	 * Note that currently Elementor supports only one category.
 	 * When multiple categories passed, Elementor uses the first one.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 *
 	 * @access public
 	 *
@@ -84,7 +84,7 @@ class Copyright extends Widget_Base {
 	/**
 	 * Register Copyright controls.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 * @access protected
 	 */
 	protected function _register_controls() { //phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
@@ -93,7 +93,7 @@ class Copyright extends Widget_Base {
 	/**
 	 * Register Copyright General Controls.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 * @access protected
 	 */
 	protected function register_content_copy_right_controls() {
@@ -182,7 +182,7 @@ class Copyright extends Widget_Base {
 	 *
 	 * Written in PHP and used to generate the final HTML.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 * @access protected
 	 */
 	protected function render() {
@@ -207,7 +207,7 @@ class Copyright extends Widget_Base {
 	 *
 	 * Override the default behavior by printing the shortcode instead of rendering it.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 * @access public
 	 */
 	public function render_plain_content() {
@@ -220,7 +220,7 @@ class Copyright extends Widget_Base {
 	 *
 	 * Written as a Backbone JavaScript template and used to generate the live preview.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 * @access protected
 	 */
 	protected function _content_template() {} //phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore

--- a/inc/widgets-manager/widgets/class-retina.php
+++ b/inc/widgets-manager/widgets/class-retina.php
@@ -58,7 +58,7 @@ class Retina extends Widget_Base {
 	 * @return string Widget title.
 	 */
 	public function get_title() {
-		return __( 'Retina Image', 'hfe' );
+		return __( 'Retina Image', 'header-footer-elementor' );
 	}
 
 	/**
@@ -115,13 +115,13 @@ class Retina extends Widget_Base {
 		$this->start_controls_section(
 			'section_retina_image',
 			[
-				'label' => __( 'Retina Image', 'hfe' ),
+				'label' => __( 'Retina Image', 'header-footer-elementor' ),
 			]
 		);
 		$this->add_control(
 			'retina_image',
 			[
-				'label'   => __( 'Choose Default Image', 'hfe' ),
+				'label'   => __( 'Choose Default Image', 'header-footer-elementor' ),
 				'type'    => Controls_Manager::MEDIA,
 				'dynamic' => [
 					'active' => true,
@@ -134,7 +134,7 @@ class Retina extends Widget_Base {
 		$this->add_control(
 			'real_retina',
 			[
-				'label'   => __( 'Choose Retina Image', 'hfe' ),
+				'label'   => __( 'Choose Retina Image', 'header-footer-elementor' ),
 				'type'    => Controls_Manager::MEDIA,
 				'dynamic' => [
 					'active' => true,
@@ -148,26 +148,26 @@ class Retina extends Widget_Base {
 			Group_Control_Image_Size::get_type(),
 			[
 				'name'    => 'retina_image',
-				'label'   => __( 'Image Size', 'hfe' ),
+				'label'   => __( 'Image Size', 'header-footer-elementor' ),
 				'default' => 'medium',
 			]
 		);
 		$this->add_responsive_control(
 			'align',
 			[
-				'label'     => __( 'Alignment', 'hfe' ),
+				'label'     => __( 'Alignment', 'header-footer-elementor' ),
 				'type'      => Controls_Manager::CHOOSE,
 				'options'   => [
 					'left'   => [
-						'title' => __( 'Left', 'hfe' ),
+						'title' => __( 'Left', 'header-footer-elementor' ),
 						'icon'  => 'fa fa-align-left',
 					],
 					'center' => [
-						'title' => __( 'Center', 'hfe' ),
+						'title' => __( 'Center', 'header-footer-elementor' ),
 						'icon'  => 'fa fa-align-center',
 					],
 					'right'  => [
-						'title' => __( 'Right', 'hfe' ),
+						'title' => __( 'Right', 'header-footer-elementor' ),
 						'icon'  => 'fa fa-align-right',
 					],
 				],
@@ -181,11 +181,11 @@ class Retina extends Widget_Base {
 		$this->add_control(
 			'caption_source',
 			[
-				'label'   => __( 'Caption', 'hfe' ),
+				'label'   => __( 'Caption', 'header-footer-elementor' ),
 				'type'    => Controls_Manager::SELECT,
 				'options' => [
-					'none'   => __( 'None', 'hfe' ),
-					'custom' => __( 'Custom Caption', 'hfe' ),
+					'none'   => __( 'None', 'header-footer-elementor' ),
+					'custom' => __( 'Custom Caption', 'header-footer-elementor' ),
 				],
 				'default' => 'none',
 			]
@@ -194,10 +194,10 @@ class Retina extends Widget_Base {
 		$this->add_control(
 			'caption',
 			[
-				'label'       => __( 'Custom Caption', 'hfe' ),
+				'label'       => __( 'Custom Caption', 'header-footer-elementor' ),
 				'type'        => Controls_Manager::TEXT,
 				'default'     => '',
-				'placeholder' => __( 'Enter your image caption', 'hfe' ),
+				'placeholder' => __( 'Enter your image caption', 'header-footer-elementor' ),
 				'condition'   => [
 					'caption_source' => 'custom',
 				],
@@ -211,12 +211,12 @@ class Retina extends Widget_Base {
 		$this->add_control(
 			'link_to',
 			[
-				'label'   => __( 'Link', 'hfe' ),
+				'label'   => __( 'Link', 'header-footer-elementor' ),
 				'type'    => Controls_Manager::SELECT,
 				'default' => 'none',
 				'options' => [
-					'none'   => __( 'None', 'hfe' ),
-					'custom' => __( 'Custom URL', 'hfe' ),
+					'none'   => __( 'None', 'header-footer-elementor' ),
+					'custom' => __( 'Custom URL', 'header-footer-elementor' ),
 				],
 			]
 		);
@@ -224,12 +224,12 @@ class Retina extends Widget_Base {
 		$this->add_control(
 			'link',
 			[
-				'label'       => __( 'Link', 'hfe' ),
+				'label'       => __( 'Link', 'header-footer-elementor' ),
 				'type'        => Controls_Manager::URL,
 				'dynamic'     => [
 					'active' => true,
 				],
-				'placeholder' => __( 'https://your-link.com', 'hfe' ),
+				'placeholder' => __( 'https://your-link.com', 'header-footer-elementor' ),
 				'condition'   => [
 					'link_to' => 'custom',
 				],
@@ -248,7 +248,7 @@ class Retina extends Widget_Base {
 		$this->start_controls_section(
 			'section_style_retina_image',
 			[
-				'label' => __( 'Retina Image', 'hfe' ),
+				'label' => __( 'Retina Image', 'header-footer-elementor' ),
 				'tab'   => Controls_Manager::TAB_STYLE,
 			]
 		);
@@ -256,7 +256,7 @@ class Retina extends Widget_Base {
 		$this->add_responsive_control(
 			'width',
 			[
-				'label'          => __( 'Width', 'hfe' ),
+				'label'          => __( 'Width', 'header-footer-elementor' ),
 				'type'           => Controls_Manager::SLIDER,
 				'default'        => [
 					'unit' => '%',
@@ -292,7 +292,7 @@ class Retina extends Widget_Base {
 		$this->add_responsive_control(
 			'space',
 			[
-				'label'          => __( 'Max Width', 'hfe' ) . ' (%)',
+				'label'          => __( 'Max Width', 'header-footer-elementor' ) . ' (%)',
 				'type'           => Controls_Manager::SLIDER,
 				'default'        => [
 					'unit' => '%',
@@ -328,16 +328,16 @@ class Retina extends Widget_Base {
 		$this->add_control(
 			'retina_image_border',
 			[
-				'label'       => __( 'Border Style', 'hfe' ),
+				'label'       => __( 'Border Style', 'header-footer-elementor' ),
 				'type'        => Controls_Manager::SELECT,
 				'default'     => 'none',
 				'label_block' => false,
 				'options'     => [
-					'none'   => __( 'None', 'hfe' ),
-					'solid'  => __( 'Solid', 'hfe' ),
-					'double' => __( 'Double', 'hfe' ),
-					'dotted' => __( 'Dotted', 'hfe' ),
-					'dashed' => __( 'Dashed', 'hfe' ),
+					'none'   => __( 'None', 'header-footer-elementor' ),
+					'solid'  => __( 'Solid', 'header-footer-elementor' ),
+					'double' => __( 'Double', 'header-footer-elementor' ),
+					'dotted' => __( 'Dotted', 'header-footer-elementor' ),
+					'dashed' => __( 'Dashed', 'header-footer-elementor' ),
 				],
 				'selectors'   => [
 					'{{WRAPPER}} .hfe-retina-image-container .hfe-retina-img' => 'border-style: {{VALUE}};',
@@ -347,7 +347,7 @@ class Retina extends Widget_Base {
 		$this->add_control(
 			'retina_image_border_size',
 			[
-				'label'      => __( 'Border Width', 'hfe' ),
+				'label'      => __( 'Border Width', 'header-footer-elementor' ),
 				'type'       => Controls_Manager::DIMENSIONS,
 				'size_units' => [ 'px' ],
 				'default'    => [
@@ -369,7 +369,7 @@ class Retina extends Widget_Base {
 		$this->add_control(
 			'retina_image_border_color',
 			[
-				'label'     => __( 'Border Color', 'hfe' ),
+				'label'     => __( 'Border Color', 'header-footer-elementor' ),
 				'type'      => Controls_Manager::COLOR,
 				'scheme'    => [
 					'type'  => Scheme_Color::get_type(),
@@ -388,7 +388,7 @@ class Retina extends Widget_Base {
 		$this->add_responsive_control(
 			'image_border_radius',
 			[
-				'label'      => __( 'Border Radius', 'hfe' ),
+				'label'      => __( 'Border Radius', 'header-footer-elementor' ),
 				'type'       => Controls_Manager::DIMENSIONS,
 				'size_units' => [ 'px', '%' ],
 				'selectors'  => [
@@ -413,14 +413,14 @@ class Retina extends Widget_Base {
 		$this->start_controls_tab(
 			'normal',
 			[
-				'label' => __( 'Normal', 'hfe' ),
+				'label' => __( 'Normal', 'header-footer-elementor' ),
 			]
 		);
 
 		$this->add_control(
 			'opacity',
 			[
-				'label'     => __( 'Opacity', 'hfe' ),
+				'label'     => __( 'Opacity', 'header-footer-elementor' ),
 				'type'      => Controls_Manager::SLIDER,
 				'range'     => [
 					'px' => [
@@ -448,13 +448,13 @@ class Retina extends Widget_Base {
 		$this->start_controls_tab(
 			'hover',
 			[
-				'label' => __( 'Hover', 'hfe' ),
+				'label' => __( 'Hover', 'header-footer-elementor' ),
 			]
 		);
 		$this->add_control(
 			'opacity_hover',
 			[
-				'label'     => __( 'Opacity', 'hfe' ),
+				'label'     => __( 'Opacity', 'header-footer-elementor' ),
 				'type'      => Controls_Manager::SLIDER,
 				'range'     => [
 					'px' => [
@@ -480,14 +480,14 @@ class Retina extends Widget_Base {
 		$this->add_control(
 			'hover_animation',
 			[
-				'label' => __( 'Hover Animation', 'hfe' ),
+				'label' => __( 'Hover Animation', 'header-footer-elementor' ),
 				'type'  => Controls_Manager::HOVER_ANIMATION,
 			]
 		);
 		$this->add_control(
 			'background_hover_transition',
 			[
-				'label'     => __( 'Transition Duration', 'hfe' ),
+				'label'     => __( 'Transition Duration', 'header-footer-elementor' ),
 				'type'      => Controls_Manager::SLIDER,
 				'range'     => [
 					'px' => [
@@ -517,7 +517,7 @@ class Retina extends Widget_Base {
 		$this->start_controls_section(
 			'section_style_caption',
 			[
-				'label'     => __( 'Caption', 'hfe' ),
+				'label'     => __( 'Caption', 'header-footer-elementor' ),
 				'tab'       => Controls_Manager::TAB_STYLE,
 				'condition' => [
 					'caption_source!' => 'none',
@@ -528,7 +528,7 @@ class Retina extends Widget_Base {
 		$this->add_control(
 			'text_color',
 			[
-				'label'     => __( 'Text Color', 'hfe' ),
+				'label'     => __( 'Text Color', 'header-footer-elementor' ),
 				'type'      => Controls_Manager::COLOR,
 				'default'   => '',
 				'selectors' => [
@@ -544,7 +544,7 @@ class Retina extends Widget_Base {
 		$this->add_control(
 			'caption_background_color',
 			[
-				'label'     => __( 'Background Color', 'hfe' ),
+				'label'     => __( 'Background Color', 'header-footer-elementor' ),
 				'type'      => Controls_Manager::COLOR,
 				'selectors' => [
 					'{{WRAPPER}} .widget-image-caption' => 'background-color: {{VALUE}};',
@@ -572,7 +572,7 @@ class Retina extends Widget_Base {
 		$this->add_responsive_control(
 			'caption_padding',
 			[
-				'label'      => __( 'Padding', 'hfe' ),
+				'label'      => __( 'Padding', 'header-footer-elementor' ),
 				'type'       => Controls_Manager::DIMENSIONS,
 				'size_units' => [ 'px', 'em', '%' ],
 				'selectors'  => [
@@ -583,7 +583,7 @@ class Retina extends Widget_Base {
 		$this->add_responsive_control(
 			'caption_space',
 			[
-				'label'     => __( 'Caption Top Spacing', 'hfe' ),
+				'label'     => __( 'Caption Top Spacing', 'header-footer-elementor' ),
 				'type'      => Controls_Manager::SLIDER,
 				'range'     => [
 					'px' => [
@@ -614,7 +614,7 @@ class Retina extends Widget_Base {
 			$this->start_controls_section(
 				'section_helpful_info',
 				[
-					'label' => __( 'Helpful Information', 'hfe' ),
+					'label' => __( 'Helpful Information', 'header-footer-elementor' ),
 				]
 			);
 
@@ -623,7 +623,7 @@ class Retina extends Widget_Base {
 				[
 					'type'            => Controls_Manager::RAW_HTML,
 					/* translators: %1$s doc link */
-					'raw'             => sprintf( __( '%1$s Getting started article » %2$s', 'hfe' ), '<a href="https://uaelementor.com/docs/introducing-retina-image-widget/" target="_blank" rel="noopener">', '</a>' ),
+					'raw'             => sprintf( __( '%1$s Getting started article » %2$s', 'header-footer-elementor' ), '<a href="https://uaelementor.com/docs/introducing-retina-image-widget/" target="_blank" rel="noopener">', '</a>' ),
 					'content_classes' => 'hfe-editor-doc',
 				]
 			);

--- a/inc/widgets-manager/widgets/class-retina.php
+++ b/inc/widgets-manager/widgets/class-retina.php
@@ -31,14 +31,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * HFE widget for Retina Image.
  *
- * @since x.x.x
+ * @since 1.2.0
  */
 class Retina extends Widget_Base {
 
 	/**
 	 * Retrieve the widget name.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 *
 	 * @access public
 	 *
@@ -51,7 +51,7 @@ class Retina extends Widget_Base {
 	/**
 	 * Retrieve the widget title.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 *
 	 * @access public
 	 *
@@ -64,7 +64,7 @@ class Retina extends Widget_Base {
 	/**
 	 * Retrieve the widget icon.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 *
 	 * @access public
 	 *
@@ -82,7 +82,7 @@ class Retina extends Widget_Base {
 	 * Note that currently Elementor supports only one category.
 	 * When multiple categories passed, Elementor uses the first one.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 *
 	 * @access public
 	 *
@@ -95,7 +95,7 @@ class Retina extends Widget_Base {
 	/**
 	 * Register Retina Logo controls.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 * @access protected
 	 */
 	protected function _register_controls() {
@@ -108,7 +108,7 @@ class Retina extends Widget_Base {
 	/**
 	 * Register Retina Logo General Controls.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 * @access protected
 	 */
 	protected function register_content_retina_image_controls() {
@@ -241,7 +241,7 @@ class Retina extends Widget_Base {
 	/**
 	 * Register Retina Image Style Controls.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 * @access protected
 	 */
 	protected function register_retina_image_styling_controls() {
@@ -510,7 +510,7 @@ class Retina extends Widget_Base {
 	/**
 	 * Register Caption style Controls.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 * @access protected
 	 */
 	protected function register_retina_caption_styling_controls() {
@@ -607,7 +607,7 @@ class Retina extends Widget_Base {
 	/**
 	 * Helpful Information.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 * @access protected
 	 */
 	protected function register_helpful_information() {
@@ -635,7 +635,7 @@ class Retina extends Widget_Base {
 	 * Check if the current widget has caption
 	 *
 	 * @access private
-	 * @since x.x.x
+	 * @since 1.2.0
 	 *
 	 * @param array $settings returns settings.
 	 *
@@ -649,7 +649,7 @@ class Retina extends Widget_Base {
 	 * Get the caption for current widget.
 	 *
 	 * @access private
-	 * @since x.x.x
+	 * @since 1.2.0
 	 * @param array $settings returns the caption.
 	 *
 	 * @return string
@@ -667,7 +667,7 @@ class Retina extends Widget_Base {
 	 *
 	 * Written in PHP and used to generate the final HTML.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 * @access protected
 	 */
 	protected function render() {
@@ -821,7 +821,7 @@ class Retina extends Widget_Base {
 	/**
 	 * Retrieve Retina image widget link URL.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 * @access private
 	 *
 	 * @param array $settings returns settings.

--- a/languages/header-footer-elementor.pot
+++ b/languages/header-footer-elementor.pot
@@ -1,11 +1,11 @@
 # Copyright (C) 2019 Brainstorm Force, Nikhil Chavan
-# This file is distributed under the same license as the Header, Footer & Blocks for Elementor package.
+# This file is distributed under the same license as the Elementor - Header, Footer & Blocks package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Header, Footer & Blocks for Elementor 1.1.2\n"
+"Project-Id-Version: Elementor - Header, Footer & Blocks 1.2.0-beta.1\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/header-footer-elementor\n"
-"POT-Creation-Date: 2019-01-16 07:15:45+00:00\n"
+"POT-Creation-Date: 2019-12-09 06:37:46+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -23,121 +23,195 @@ msgstr ""
 "X-Poedit-SearchPath-0: .\n"
 "X-Poedit-Bookmarks: \n"
 "X-Textdomain-Support: yes\n"
-"X-Generator: grunt-wp-i18n1.0.2\n"
+"X-Generator: grunt-wp-i18n 1.0.3\n"
 
-#: admin/class-hfe-admin.php:61 admin/class-hfe-admin.php:63
+#: admin/class-hfe-admin.php:60 admin/class-hfe-admin.php:62
 msgid "Header Footers Template"
 msgstr ""
 
-#: admin/class-hfe-admin.php:62 admin/class-hfe-admin.php:64
+#: admin/class-hfe-admin.php:61 admin/class-hfe-admin.php:63
 msgid "Elementor Header Footer"
 msgstr ""
 
-#: admin/class-hfe-admin.php:65
+#: admin/class-hfe-admin.php:64
 msgid "Add New"
 msgstr ""
 
-#: admin/class-hfe-admin.php:66
+#: admin/class-hfe-admin.php:65
 msgid "Add New Header Footer"
 msgstr ""
 
-#: admin/class-hfe-admin.php:67
+#: admin/class-hfe-admin.php:66
 msgid "New Header Footers Template"
 msgstr ""
 
-#: admin/class-hfe-admin.php:68
+#: admin/class-hfe-admin.php:67
 msgid "Edit Header Footers Template"
 msgstr ""
 
-#: admin/class-hfe-admin.php:69
+#: admin/class-hfe-admin.php:68
 msgid "View Header Footers Template"
 msgstr ""
 
-#: admin/class-hfe-admin.php:70
+#: admin/class-hfe-admin.php:69
 msgid "All Elementor Header Footers"
 msgstr ""
 
-#: admin/class-hfe-admin.php:71
+#: admin/class-hfe-admin.php:70
 msgid "Search Header Footers Templates"
 msgstr ""
 
-#: admin/class-hfe-admin.php:72
+#: admin/class-hfe-admin.php:71
 msgid "Parent Header Footers Templates:"
 msgstr ""
 
-#: admin/class-hfe-admin.php:73
+#: admin/class-hfe-admin.php:72
 msgid "No Header Footers Templates found."
 msgstr ""
 
-#: admin/class-hfe-admin.php:74
+#: admin/class-hfe-admin.php:73
 msgid "No Header Footers Templates found in Trash."
 msgstr ""
 
-#: admin/class-hfe-admin.php:104 admin/class-hfe-admin.php:105
+#: admin/class-hfe-admin.php:102 admin/class-hfe-admin.php:103
 msgid "Header Footer Builder"
 msgstr ""
 
-#: admin/class-hfe-admin.php:117
+#: admin/class-hfe-admin.php:115
 msgid "Elementor Header Footer options"
 msgstr ""
 
-#: admin/class-hfe-admin.php:145
+#: admin/class-hfe-admin.php:143
 msgid "Type of Template"
 msgstr ""
 
-#: admin/class-hfe-admin.php:149
+#: admin/class-hfe-admin.php:147
 msgid "Select Option"
 msgstr ""
 
-#: admin/class-hfe-admin.php:150
+#: admin/class-hfe-admin.php:148
 msgid "Header"
 msgstr ""
 
-#: admin/class-hfe-admin.php:152
+#: admin/class-hfe-admin.php:149
 msgid "Before Footer"
 msgstr ""
 
-#: admin/class-hfe-admin.php:154
+#: admin/class-hfe-admin.php:150
 msgid "Footer"
 msgstr ""
 
-#: admin/class-hfe-admin.php:155
+#: admin/class-hfe-admin.php:151
 msgid "Custom Block"
 msgstr ""
 
-#: admin/class-hfe-admin.php:161 admin/class-hfe-admin.php:321
+#: admin/class-hfe-admin.php:159 admin/class-hfe-admin.php:404
 msgid "Shortcode"
 msgstr ""
 
-#: admin/class-hfe-admin.php:162
+#: admin/class-hfe-admin.php:160
 msgid ""
 "Copy this shortcode and paste it into your post, page, or text widget "
 "content."
 msgstr ""
 
-#: admin/class-hfe-admin.php:174
+#: admin/class-hfe-admin.php:172
 msgid "Enable Layout for Elementor Canvas Template?"
 msgstr ""
 
-#: admin/class-hfe-admin.php:176
+#: admin/class-hfe-admin.php:174
 msgid ""
 "Enabling this option will display this layout on pages using Elementor "
 "Canvas Template."
 msgstr ""
 
-#: admin/class-hfe-admin.php:248
+#: admin/class-hfe-admin.php:200
+msgid "Display On"
+msgstr ""
+
+#: admin/class-hfe-admin.php:202
+msgid "Add locations for where this template should appear."
+msgstr ""
+
+#: admin/class-hfe-admin.php:209
+msgid "Display Rules"
+msgstr ""
+
+#: admin/class-hfe-admin.php:213
+msgid "Add Display Rule"
+msgstr ""
+
+#: admin/class-hfe-admin.php:222
+msgid "Do Not Display On"
+msgstr ""
+
+#: admin/class-hfe-admin.php:224
+msgid "This Advanced Header will not appear at these locations."
+msgstr ""
+
+#: admin/class-hfe-admin.php:231
+msgid "Exclude On"
+msgstr ""
+
+#: admin/class-hfe-admin.php:234
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:840
+msgid "Add Exclusion Rule"
+msgstr ""
+
+#: admin/class-hfe-admin.php:244
+msgid "User Roles"
+msgstr ""
+
+#: admin/class-hfe-admin.php:245
+msgid "Targer header based on user role."
+msgstr ""
+
+#: admin/class-hfe-admin.php:252
+msgid "Users"
+msgstr ""
+
+#: admin/class-hfe-admin.php:255
+msgid "Add User Rule"
+msgstr ""
+
+#: admin/class-hfe-admin.php:335
 #. Translators: Post title, Template Location
 msgid "Template %1$s is already assigned to the location %2$s"
 msgstr ""
 
-#: inc/class-header-footer-elementor.php:101
+#: inc/class-header-footer-elementor.php:142
+msgid ""
+"Hello! Seems like you have used Elementor - Header, Footer & Blocks to "
+"build this website — Thanks a ton!"
+msgstr ""
+
+#: inc/class-header-footer-elementor.php:143
+msgid ""
+"Could you please do us a BIG favor and give it a 5-star rating on "
+"WordPress? This would boost our motivation and help other users make a "
+"comfortable decision while choosing the Elementor - Header, Footer & Blocks."
+msgstr ""
+
+#: inc/class-header-footer-elementor.php:145
+msgid "Ok, you deserve it"
+msgstr ""
+
+#: inc/class-header-footer-elementor.php:147
+msgid "Nope, maybe later"
+msgstr ""
+
+#: inc/class-header-footer-elementor.php:148
+msgid "I already did"
+msgstr ""
+
+#: inc/class-header-footer-elementor.php:181
 #. Translators: URL to install or activate Elementor plugin.
 msgid ""
 "The <strong>Header Footer Elementor</strong> plugin requires <strong><a "
 "href=\"%s\">Elementor</strong></a> plugin installed & activated."
 msgstr ""
 
-#: inc/class-header-footer-elementor.php:219
+#: inc/class-header-footer-elementor.php:313
 msgid ""
 "Hey, your current theme is not supported by Header Footer Elementor, click "
 "<a "
@@ -145,8 +219,384 @@ msgid ""
 "are-supported-by-this-plugin\">here</a> to check out the supported themes."
 msgstr ""
 
+#: inc/lib/notices/class-astra-notices.php:120
+msgid "WordPress Nonce not validated."
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:127
+msgid "404 Page"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:128
+msgid "Search Page"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:129
+msgid "Blog / Posts Page"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:130
+msgid "Front Page"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:131
+msgid "Date Archive"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:132
+msgid "Author Archive"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:136
+msgid "WooCommerce Shop Page"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:141
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:213
+msgid "Basic"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:143
+msgid "Entire Website"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:144
+msgid "All Singulars"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:145
+msgid "All Archives"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:150
+msgid "Special Pages"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:191
+msgid "Specific Target"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:193
+msgid "Specific Pages / Posts / Taxanomies, etc."
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:215
+msgid "All"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:216
+msgid "Logged In"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:217
+msgid "Logged Out"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:222
+msgid "Advanced"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:619
+msgid "Please enter"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:620
+msgid "Please delete"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:621
+msgid "or more characters"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:622
+msgid "character"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:623
+msgid "Loading more results…"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:624
+msgid "You can only select"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:625
+msgid "item"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:626
+msgid "s"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:627
+msgid "No results found"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:628
+msgid "Searching…"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:629
+msgid "The results could not be loaded."
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:630
+msgid "Search pages / post / categories"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:648
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:1057
+msgid "Add Rule"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:664
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:769
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:1073
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:1103
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:1553
+msgid "Select"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:714
+#. translators: %s post label
+msgid "All %s"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:719
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:728
+#. translators: %s post label
+#. translators: %s taxonomy label
+msgid "All %s Archive"
+msgstr ""
+
+#: inc/lib/target-rule/class-astra-target-rules-fields.php:1494
+#. translators: %s post title.
+msgid "The same display setting is already exist in %s post/s."
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-copyright.php:53
+#: inc/widgets-manager/widgets/class-copyright.php:103
+msgid "Copyright"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-copyright.php:110
+msgid "Copyright Text"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-copyright.php:115
+msgid ""
+"Copyright © [hfe_current_year] [hfe_site_title] | Powered by "
+"[hfe_site_title]"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-copyright.php:122
+#: inc/widgets-manager/widgets/class-retina.php:214
+#: inc/widgets-manager/widgets/class-retina.php:227
+msgid "Link"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-copyright.php:124
+#: inc/widgets-manager/widgets/class-retina.php:232
+msgid "https://your-link.com"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-copyright.php:131
+#: inc/widgets-manager/widgets/class-retina.php:158
+msgid "Alignment"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-copyright.php:135
+#: inc/widgets-manager/widgets/class-retina.php:162
+msgid "Left"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-copyright.php:139
+#: inc/widgets-manager/widgets/class-retina.php:166
+msgid "Center"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-copyright.php:143
+#: inc/widgets-manager/widgets/class-retina.php:170
+msgid "Right"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-copyright.php:156
+#: inc/widgets-manager/widgets/class-retina.php:531
+msgid "Text Color"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:61
+#: inc/widgets-manager/widgets/class-retina.php:118
+#: inc/widgets-manager/widgets/class-retina.php:251
+msgid "Retina Image"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:124
+msgid "Choose Default Image"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:137
+msgid "Choose Retina Image"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:151
+msgid "Image Size"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:184
+#: inc/widgets-manager/widgets/class-retina.php:520
+msgid "Caption"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:187
+#: inc/widgets-manager/widgets/class-retina.php:218
+#: inc/widgets-manager/widgets/class-retina.php:336
+msgid "None"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:188
+#: inc/widgets-manager/widgets/class-retina.php:197
+msgid "Custom Caption"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:200
+msgid "Enter your image caption"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:219
+msgid "Custom URL"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:259
+msgid "Width"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:295
+msgid "Max Width"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:331
+msgid "Border Style"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:337
+msgid "Solid"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:338
+msgid "Double"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:339
+msgid "Dotted"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:340
+msgid "Dashed"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:350
+msgid "Border Width"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:372
+msgid "Border Color"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:391
+msgid "Border Radius"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:416
+msgid "Normal"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:423
+#: inc/widgets-manager/widgets/class-retina.php:457
+msgid "Opacity"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:451
+msgid "Hover"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:483
+msgid "Hover Animation"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:490
+msgid "Transition Duration"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:547
+msgid "Background Color"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:575
+msgid "Padding"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:586
+msgid "Caption Top Spacing"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:617
+msgid "Helpful Information"
+msgstr ""
+
+#: inc/widgets-manager/widgets/class-retina.php:626
+#. translators: %1$s doc link
+msgid "%1$s Getting started article » %2$s"
+msgstr ""
+
+#: themes/default/class-hfe-fallback-theme-support.php:66
+msgid "Compatibility Mode"
+msgstr ""
+
+#: themes/default/class-hfe-fallback-theme-support.php:79
+msgid ""
+"Header Footer Elementor plugin includes two compatibility modes to try to "
+"support all the themes.<br>Use the method which works best with your "
+"theme.<br><br>It is possible that both these methods will not work with "
+"your theme correctly with your theme, In that case you should contact your "
+"theme author and request them to <a "
+"href=\"https://github.com/Nikschavan/header-footer-elementor/wiki/Adding-"
+"Header-Footer-Elementor-support-for-your-theme\" target=\"_blank\">add "
+"support for this plugin</a>."
+msgstr ""
+
+#: themes/default/class-hfe-fallback-theme-support.php:96
+msgid "Method 1"
+msgstr ""
+
+#: themes/default/class-hfe-fallback-theme-support.php:97
+msgid ""
+"This replaces the header.php & footer.php template with a custom templates "
+"from the plugin."
+msgstr ""
+
+#: themes/default/class-hfe-fallback-theme-support.php:100
+msgid "Method 2"
+msgstr ""
+
+#: themes/default/class-hfe-fallback-theme-support.php:140
+#: themes/default/class-hfe-fallback-theme-support.php:141
+#: themes/default/class-hfe-fallback-theme-support.php:169
+#: themes/default/class-hfe-fallback-theme-support.php:210
+msgid "Settings"
+msgstr ""
+
+#: themes/default/class-hfe-fallback-theme-support.php:157
+msgid "Elementor - Header, Footer & Blocks "
+msgstr ""
+
+#: themes/default/class-hfe-fallback-theme-support.php:165
+#: themes/default/class-hfe-fallback-theme-support.php:206
+msgid "All templates"
+msgstr ""
+
 #. Plugin Name of the plugin/theme
-msgid "Header, Footer & Blocks for Elementor"
+msgid "Elementor - Header, Footer & Blocks"
 msgstr ""
 
 #. Plugin URI of the plugin/theme

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "header-footer-elementor",
-  "version": "1.1.2",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -34,6 +34,13 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
         "sprintf-js": "~1.0.2"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+        }
       }
     },
     "array-find-index": {
@@ -475,9 +482,9 @@
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
     "grunt": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.3.tgz",
-      "integrity": "sha512-/JzmZNPfKorlCrrmxWqQO4JVodO+DVd5XX4DkocL/1WlLlKVLE9+SdEIempOAxDhWPysLle6afvn/hg7Ck2k9g==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.4.tgz",
+      "integrity": "sha512-PYsMOrOC+MsdGEkFVwMaMyc6Ob7pKmq+deg1Sjr+vvMWp35sztfwKE7qoN51V+UEtHsyNuMcGdgMLFkBHvMxHQ==",
       "dev": true,
       "requires": {
         "coffeescript": "~1.10.0",
@@ -491,7 +498,7 @@
         "grunt-legacy-log": "~2.0.0",
         "grunt-legacy-util": "~1.1.1",
         "iconv-lite": "~0.4.13",
-        "js-yaml": "~3.5.2",
+        "js-yaml": "~3.13.0",
         "minimatch": "~3.0.2",
         "mkdirp": "~0.5.1",
         "nopt": "~3.0.6",
@@ -499,12 +506,6 @@
         "rimraf": "~2.6.2"
       },
       "dependencies": {
-        "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-          "dev": true
-        },
         "grunt-cli": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
@@ -517,20 +518,28 @@
             "resolve": "~1.1.0"
           }
         },
-        "js-yaml": {
-          "version": "3.5.5",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
-          "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.2",
-            "esprima": "^2.6.0"
-          }
-        },
         "resolve": {
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-bumpup": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/grunt-bumpup/-/grunt-bumpup-0.6.3.tgz",
+      "integrity": "sha1-dU6Wu2pTN9C5VInl3EmWuvyLtBQ=",
+      "dev": true,
+      "requires": {
+        "moment": "^2.8.3",
+        "semver": "^4.0.3"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "4.3.6",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
           "dev": true
         }
       }
@@ -617,6 +626,12 @@
         "which": "~1.3.0"
       }
     },
+    "grunt-text-replace": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/grunt-text-replace/-/grunt-text-replace-0.4.0.tgz",
+      "integrity": "sha1-252c5Z4v5J2id+nbwZXD4Rz7FsI=",
+      "dev": true
+    },
     "grunt-wp-i18n": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/grunt-wp-i18n/-/grunt-wp-i18n-1.0.3.tgz",
@@ -653,9 +668,9 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+      "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
       "dev": true
     },
     "iconv-lite": {
@@ -794,9 +809,9 @@
       "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo="
     },
     "js-yaml": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -848,9 +863,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -938,6 +953,12 @@
           "dev": true
         }
       }
+    },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.1",
@@ -3164,9 +3185,9 @@
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "resolve": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.13.1.tgz",
+      "integrity": "sha512-CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -3182,9 +3203,9 @@
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -3276,15 +3297,16 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
-      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
     "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+      "dev": true
     },
     "string-width": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "header-footer-elementor",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0-beta.2",
   "main": "Gruntfile.js",
   "author": "Nikhil Chavan",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "header-footer-elementor",
-  "version": "1.1.4",
+  "version": "1.2.0-beta.1",
   "main": "Gruntfile.js",
   "author": "Nikhil Chavan",
   "devDependencies": {
-    "grunt": "~1.0.3",
+    "grunt": "^1.0.4",
+    "grunt-bumpup": "^0.6.3",
+    "grunt-text-replace": "^0.4.0",
     "grunt-wp-i18n": "~1.0.3",
     "grunt-wp-readme-to-markdown": "~2.0.1"
   },

--- a/readme.txt
+++ b/readme.txt
@@ -110,10 +110,10 @@ If the above is nnot possible, You can also add support for the plugin from your
 
 = 1.2.0 (Unreleased) =
 - New: Support all the themes, Includes two separate fallback methods so that you can create custom headers and footers for any theme.
-- New: Added target rule engine which allows you to have different headers/footer for different pages.
-- New: Added Retina Image Elementor widget which can be used as a Site Logo.
+- New: Added target rule engine, which allows you to have different headers/footers for different pages.
+- New: Added Retina Image Elementor widget, which can be used as a Site Logo.
 - New: Added Copyright widget and Shortcode for current year & site title.
-- Improvement: Allow before footer to work on Elementor Canvas Template when not usina Astra Theme.
+- Improvement: Allow before footer to work on Elementor Canvas Template when not using Astra Theme.
 - Improvement: Added support of `Before Footer` action for all the themes.
 
 = 1.1.4 =

--- a/readme.txt
+++ b/readme.txt
@@ -109,8 +109,12 @@ If the above is nnot possible, You can also add support for the plugin from your
 == Changelog ==
 
 = 1.2.0 (Unreleased) =
-- Improvement: Allow before footer to work on Elementor Canvas Template when not usina Astra Theme.
+- New: Support all the themes, Includes two separate fallback methods so that you can create custom headers and footers for any theme.
+- New: Added target rule engine which allows you to have different headers/footer for different pages.
+- New: Added Retina Image Elementor widget which can be used as a Site Logo.
 - New: Added Copyright widget and Shortcode for current year & site title.
+- Improvement: Allow before footer to work on Elementor Canvas Template when not usina Astra Theme.
+- Improvement: Added support of `Before Footer` action for all the themes.
 
 = 1.1.4 =
 - Fix: Flush permalinks on plugin update to Elementor error when trying to edit the Header/Footer.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://www.paypal.me/BrainstormForce
 Requires at least: 4.4
 Requires PHP: 5.4
 Tested up to: 5.3
-Stable tag: 1.2.0-beta.1
+Stable tag: 1.2.0-beta.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://www.paypal.me/BrainstormForce
 Requires at least: 4.4
 Requires PHP: 5.4
 Tested up to: 5.3
-Stable tag: 1.1.4
+Stable tag: 1.2.0-beta.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/themes/default/class-global-theme-compatibility.php
+++ b/themes/default/class-global-theme-compatibility.php
@@ -47,7 +47,7 @@ class Global_Theme_Compatibility {
 	/**
 	 * Force full width CSS for the header.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 * @return void
 	 */
 	public function force_fullwidth() {
@@ -77,7 +77,7 @@ class Global_Theme_Compatibility {
 	/**
 	 * Function overriding the header in the wp_body_open way.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 *
 	 * @return void
 	 */

--- a/themes/default/class-hfe-default-compat.php
+++ b/themes/default/class-hfe-default-compat.php
@@ -49,7 +49,7 @@ class HFE_Default_Compat {
 	/**
 	 * Function for overriding the header in the elmentor way.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 *
 	 * @return void
 	 */
@@ -67,7 +67,7 @@ class HFE_Default_Compat {
 	/**
 	 * Function for overriding the footer in the elmentor way.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 *
 	 * @return void
 	 */

--- a/themes/default/class-hfe-fallback-theme-support.php
+++ b/themes/default/class-hfe-fallback-theme-support.php
@@ -4,7 +4,7 @@
  *
  * Add theme compatibility for all the WordPress themes.
  *
- * @since x.x.x
+ * @since 1.2.0
  * @package hfe
  */
 
@@ -13,14 +13,14 @@ namespace HFE\Themes;
 /**
  * Class HFE Theme Fallback support.
  *
- * @since x.x.x
+ * @since 1.2.0
  */
 class HFE_Fallback_Theme_Support {
 
 	/**
 	 * Constructor.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 */
 	public function __construct() {
 		$this->setup_fallback_support();
@@ -34,7 +34,7 @@ class HFE_Fallback_Theme_Support {
 	/**
 	 * Adds CSS to Hide the extra submenu added for the settings tab.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 * @return void
 	 */
 	public function hfe_global_css() {
@@ -44,7 +44,7 @@ class HFE_Fallback_Theme_Support {
 	/**
 	 * Adds a tab in plugin submenu page.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 * @param string $views to add tab to current post type view.
 	 *
 	 * @return mixed
@@ -58,7 +58,7 @@ class HFE_Fallback_Theme_Support {
 	/**
 	 * Function for registering the settings api.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 * @return void
 	 */
 	public function hfe_admin_init() {
@@ -72,7 +72,7 @@ class HFE_Fallback_Theme_Support {
 	 *
 	 * This function can be used to add description of the settings sections
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 * @return void
 	 */
 	public function hfe_compatibility_callback() {
@@ -84,7 +84,7 @@ class HFE_Fallback_Theme_Support {
 	 *
 	 * This function will contain the markup for the input feilds that we can add.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 * @return void
 	 */
 	public function hfe_compatibility_option_callback() {
@@ -114,7 +114,7 @@ class HFE_Fallback_Theme_Support {
 	/**
 	 * Setup Theme Support.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 * @return void
 	 */
 	public function setup_fallback_support() {
@@ -130,7 +130,7 @@ class HFE_Fallback_Theme_Support {
 	/**
 	 * Show a settings page incase of unsupported theme.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 *
 	 * @return void
 	 */
@@ -150,7 +150,7 @@ class HFE_Fallback_Theme_Support {
 	 *
 	 * Call back function for add submenu page function.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 */
 	public function hfe_settings_page() {
 		echo '<h1 class="hfe-heading-inline">';
@@ -194,7 +194,7 @@ class HFE_Fallback_Theme_Support {
 	/**
 	 * Function for adding tabs
 	 *
-	 * @since x.x.x
+	 * @since 1.2.0
 	 * @return void
 	 */
 	public function hfe_tabs() {

--- a/themes/default/hfe-footer.php
+++ b/themes/default/hfe-footer.php
@@ -3,7 +3,7 @@
  * Footer file in case of the elementor way
  *
  * @package header-footer-elementor
- * @since x.x.x
+ * @since 1.2.0
  */
 
 ?>

--- a/themes/default/hfe-header.php
+++ b/themes/default/hfe-header.php
@@ -3,7 +3,7 @@
  * Header file in case of the elementor way
  *
  * @package header-footer-elementor
- * @since x.x.x
+ * @since 1.2.0
  */
 
 ?><!DOCTYPE html>


### PR DESCRIPTION
#### v1.2.0
- New: Support all the themes, Includes two separate fallback methods so that you can create custom headers and footers for any theme.
- New: Added target rule engine, which allows you to have different headers/footers for different pages.
- New: Added Retina Image Elementor widget, which can be used as a Site Logo.
- New: Added Copyright widget and Shortcode for current year & site title.
- Improvement: Allow before footer to work on Elementor Canvas Template when not using Astra Theme.
- Improvement: Added support of `Before Footer` action for all the themes.