### PR TITLE
GeneratePress double header issue 

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -138,7 +138,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 == Changelog ==
 
 = 1.5.0 =
-- Fix: GeneratePress theme header not overring by EHF.
+- Fix: GeneratePress theme header not overriding by EHF.
 
 = 1.4.1 =
 - Fix: EHF header overlapping Astra WooCommerce Off-Canvas.

--- a/readme.txt
+++ b/readme.txt
@@ -138,7 +138,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 == Changelog ==
 
 = 1.5.0 =
-- Fix: GeneratePress theme header not overriding by EHF.
+- Fix: GeneratePress theme header now overriden by EHF.
 
 = 1.4.1 =
 - Fix: EHF header overlapping Astra WooCommerce Off-Canvas.

--- a/readme.txt
+++ b/readme.txt
@@ -137,6 +137,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 == Changelog ==
 
+= 1.5.0 =
+- Fix: GeneratePress theme header not overring by EHF.
+
 = 1.4.1 =
 - Fix: EHF header overlapping Astra WooCommerce Off-Canvas.
 - Fix: WooCommerce Menu Cart - 'div' tag of custom cart layout was not closed.

--- a/themes/generatepress/class-hfe-generatepress-compat.php
+++ b/themes/generatepress/class-hfe-generatepress-compat.php
@@ -56,6 +56,7 @@ class HFE_GeneratePress_Compat {
 	 */
 	public function generatepress_setup_header() {
 		remove_action( 'generate_header', 'generate_construct_header' );
+		remove_action( 'generate_after_header', 'generate_add_navigation_after_header', 5 );
 	}
 
 	/**


### PR DESCRIPTION
### Description
Remove action is used to remove the GeneratePress header when HFE Header is present.

### Screenshots
Issue - https://cl.ly/397935bbed80 
After removing action - https://cl.ly/86332e31bb8e

### Types of changes
remove_action() is used to remove function after header.

### How has this been tested?
1. Tested with GeneratePress version 2.4.1 & 2.4.2
2. If HFE header is present - Output: Only HFE header should show on the frontend.
3. When HFE Header is not present by default WP header should show.

### Checklist:
- [x] My code is tested 
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ --> - Tested
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ --> - Tested
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->