### PR TITLE
Fix: Post Title - Added support to archive title.

### DIFF
--- a/inc/widgets-manager/widgets/class-page-title.php
+++ b/inc/widgets-manager/widgets/class-page-title.php
@@ -392,7 +392,7 @@ class Page_Title extends Widget_Base {
 	 * @access protected
 	 */
 	protected function render() {
-		if( ! is_home( ) ) {
+		if( ! is_home() ) {
 		$settings = $this->get_settings_for_display();
 
 		$this->add_inline_editing_attributes( 'page_title', 'basic' );
@@ -451,6 +451,8 @@ class Page_Title extends Widget_Base {
 	 * @access protected
 	 */
 	protected function content_template() {
+
+		if( ! is_home() ) {
 		?>
 		<#
 		if ( '' == settings.page_title ) {
@@ -485,6 +487,7 @@ class Page_Title extends Widget_Base {
 			<# } #>			
 		</div>
 		<?php
+		}
 	}
 
 	/**

--- a/inc/widgets-manager/widgets/class-page-title.php
+++ b/inc/widgets-manager/widgets/class-page-title.php
@@ -392,7 +392,7 @@ class Page_Title extends Widget_Base {
 	 * @access protected
 	 */
 	protected function render() {
-		if( ! is_home() ) {
+
 		$settings = $this->get_settings_for_display();
 
 		$this->add_inline_editing_attributes( 'page_title', 'basic' );
@@ -412,8 +412,8 @@ class Page_Title extends Widget_Base {
 		?>		
 		<div class="hfe-page-title hfe-page-title-wrapper elementor-widget-heading">
 
-		<?php 
-		$head_link_url = isset( $settings['page_heading_link']['url'] ) ? $settings['page_heading_link']['url'] : '';
+		<?php
+		$head_link_url    = isset( $settings['page_heading_link']['url'] ) ? $settings['page_heading_link']['url'] : '';
 		$head_custom_link = isset( $settings['page_custom_link'] ) ? $settings['page_custom_link'] : '';
 		?>
 			<?php if ( '' != $head_link_url && 'custom' === $head_custom_link ) { ?>
@@ -428,19 +428,25 @@ class Page_Title extends Widget_Base {
 				<?php } ?>				
 				<?php if ( '' != $settings['before'] ) { ?>
 					<?php echo wp_kses_post( $settings['before'] ); ?>
-				<?php } ?>
+					<?php
+				}
 
-				<?php echo wp_kses_post( get_the_title() ); ?>
+				if ( is_archive() || is_home() ) {
+					echo wp_kses_post( get_the_archive_title() );
+				} else {
+					echo wp_kses_post( get_the_title() );
+				}
 
-				<?php if ( '' != $settings['after'] ) { ?>
+				if ( '' != $settings['after'] ) {
+					?>
 					<?php echo wp_kses_post( $settings['after'] ); ?>
 				<?php } ?>  
 			</<?php echo wp_kses_post( $settings['heading_tag'] ); ?> > 
 			</a>    
 		</div>
 		<?php
-		}	
-}
+
+	}
 
 	/**
 	 * Render page title output in the editor.
@@ -452,7 +458,6 @@ class Page_Title extends Widget_Base {
 	 */
 	protected function content_template() {
 
-		if( ! is_home() ) {
 		?>
 		<#
 		if ( '' == settings.page_title ) {
@@ -477,7 +482,13 @@ class Page_Title extends Widget_Base {
 					<# if ( '' != settings.before ) { #>
 						{{{ settings.before }}}
 					<# } #>
-				<?php echo wp_kses_post( get_the_title() ); ?>
+					<?php
+					if ( is_archive() || is_home() ) {
+						echo wp_kses_post( get_the_archive_title() );
+					} else {
+						echo wp_kses_post( get_the_title() );
+					}
+					?>
 					<# if ( '' != settings.after ) { #>
 						{{{ settings.after }}}
 					<# } #>				
@@ -487,7 +498,6 @@ class Page_Title extends Widget_Base {
 			<# } #>			
 		</div>
 		<?php
-		}
 	}
 
 	/**

--- a/inc/widgets-manager/widgets/class-page-title.php
+++ b/inc/widgets-manager/widgets/class-page-title.php
@@ -392,6 +392,7 @@ class Page_Title extends Widget_Base {
 	 * @access protected
 	 */
 	protected function render() {
+		if( ! is_home( ) ) {
 		$settings = $this->get_settings_for_display();
 
 		$this->add_inline_editing_attributes( 'page_title', 'basic' );
@@ -410,8 +411,13 @@ class Page_Title extends Widget_Base {
 		}
 		?>		
 		<div class="hfe-page-title hfe-page-title-wrapper elementor-widget-heading">
-			<?php if ( '' != $settings['page_heading_link']['url'] && 'custom' === $settings['page_custom_link'] ) { ?>
-						<a <?php echo esc_attr( $link ); ?> >
+
+		<?php 
+		$head_link_url = isset( $settings['page_heading_link']['url'] ) ? $settings['page_heading_link']['url'] : '';
+		$head_custom_link = isset( $settings['page_custom_link'] ) ? $settings['page_custom_link'] : '';
+		?>
+			<?php if ( '' != $head_link_url && 'custom' === $head_custom_link ) { ?>
+						<a <?php echo $link; ?> >
 			<?php } else { ?>
 						<a href="<?php echo esc_url( get_home_url() ); ?>">
 			<?php } ?>
@@ -433,7 +439,8 @@ class Page_Title extends Widget_Base {
 			</a>    
 		</div>
 		<?php
-	}
+		}	
+}
 
 	/**
 	 * Render page title output in the editor.

--- a/readme.txt
+++ b/readme.txt
@@ -139,6 +139,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 = 1.5.0 =
 - Fix: GeneratePress theme header now overriden by EHF.
+- Fix: Page Title - Added support for archive title.
 
 = 1.4.1 =
 - Fix: EHF header overlapping Astra WooCommerce Off-Canvas.


### PR DESCRIPTION
### Description
Used get_the_archive_title() function to fetch the title for archives.

### Types of changes
Non-breaking change adding support to the title of archives as well as pages.

### How has this been tested?
Tested with a simple page, blog page, and product archive page.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
