### PR TITLE
Search close icon conflict with GP theme

### DIFF
--- a/inc/js/frontend.js
+++ b/inc/js/frontend.js
@@ -9,11 +9,11 @@
 		if ( 'undefined' == typeof $scope )
 			return;
 
-		var $input = $scope.find( "input" ),
-			$clear = $scope.find( "button#clear" ),
-			$clear_with_button = $scope.find( "button#clear-with-button" ),
-			$search_button = $scope.find( ".hfe-search-submit" ),
-			$toggle_search = $scope.find( ".hfe-search-icon-toggle input" );
+			var $input = $scope.find( "input.hfe-search-form__input" );
+			var $clear = $scope.find( "button#clear" );
+			var $clear_with_button = $scope.find( "button#clear-with-button" );
+			var $search_button = $scope.find( ".hfe-search-submit" );
+			var $toggle_search = $scope.find( ".hfe-search-icon-toggle input" );
 
 		$scope.find( '.hfe-search-icon-toggle' ).on( 'click', function( ){
 			$scope.find( ".hfe-search-form__input" ).focus();						
@@ -25,13 +25,8 @@
 
 		$scope.find( ".hfe-search-form__input" ).blur( function() {
 			$scope.find( ".hfe-search-button-wrapper" ).removeClass( "hfe-input-focus" );
-			$clear.hide();
 		});
   		   
-		$input.on( "input", function(){
-		  	$clear.toggle( !!this.value );
-		  	$clear_with_button.toggle( !!this.value );
-		});
 
 		$search_button.on( 'touchstart click', function(){
 			$input.submit();
@@ -39,12 +34,22 @@
 
 		$toggle_search.css( 'padding-right', $toggle_search.next().outerWidth() + 'px' );
 
-		$( document ).on( 'touchstart click', 'button#clear, button#clear-with-button', function( e ){
-			e.preventDefault();
-			$input.val("").trigger( "input" );			
+	
+		$input.on( 'keyup', function(){
+			$clear.style = (this.value.length) ? $clear.css('visibility','visible'): $clear.css('visibility','hidden');
+			$clear_with_button.style = (this.value.length) ? $clear_with_button.css('visibility','visible'): $clear_with_button.css('visibility','hidden');
+			$clear_with_button.css( 'right', $search_button.outerWidth() + 'px' );
 		});
 
-		$clear_with_button.css( 'right', $search_button.outerWidth() + 'px' );
+		$clear.on("click",function(){
+			this.style = $clear.css('visibility','hidden');
+			$input.value = "";
+		});
+		$clear_with_button.on("click",function(){
+			this.style = $clear_with_button.css('visibility','hidden');
+			$input.value = "";
+		});
+		
 	};
 		/**
 	 * Nav Menu handler Function.

--- a/inc/widgets-css/frontend.css
+++ b/inc/widgets-css/frontend.css
@@ -1819,7 +1819,7 @@ a.hfe-menu-item.elementor-button {
 
 .hfe-search-form__container button#clear,
 .hfe-search-icon-toggle button#clear {
-    display: none;
+    visibility: hidden;
     position: absolute;
     right:0; 
     top:0;
@@ -1832,8 +1832,15 @@ a.hfe-menu-item.elementor-button {
     background-color: transparent;
 }
 
+input[type="search"]::-webkit-search-decoration,
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-results-button,
+input[type="search"]::-webkit-search-results-decoration { 
+    display: none; 
+}
+
 .hfe-search-form__container button#clear-with-button{
-    display: none;
+    visibility: hidden;
     position: absolute;
     top: 0;
     padding: 0 8px;

--- a/inc/widgets-css/frontend.css
+++ b/inc/widgets-css/frontend.css
@@ -1832,10 +1832,10 @@ a.hfe-menu-item.elementor-button {
     background-color: transparent;
 }
 
-input[type="search"]::-webkit-search-decoration,
-input[type="search"]::-webkit-search-cancel-button,
-input[type="search"]::-webkit-search-results-button,
-input[type="search"]::-webkit-search-results-decoration { 
+.hfe-search-button-wrapper input[type="search"]::-webkit-search-decoration,
+.hfe-search-button-wrapper input[type="search"]::-webkit-search-cancel-button,
+.hfe-search-button-wrapper input[type="search"]::-webkit-search-results-button,
+.hfe-search-button-wrapper input[type="search"]::-webkit-search-results-decoration { 
     display: none; 
 }
 


### PR DESCRIPTION
### Description
CSS added to hide the default GP theme close icon.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Tested with GP and Astra theme.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->