### PR TITLE
fix: Duplicate AJAX astra_get_posts_by_query action fails search results when Astra Pro is active

### DIFF
--- a/inc/lib/target-rule/class-astra-target-rules-fields.php
+++ b/inc/lib/target-rule/class-astra-target-rules-fields.php
@@ -91,7 +91,7 @@ class Astra_Target_Rules_Fields {
 		define( 'AST_TARGET_RULE_DIR', plugin_dir_path( __FILE__ ) );
 
 		add_action( 'admin_action_edit', array( $this, 'initialize_options' ) );
-		add_action( 'wp_ajax_astra_get_posts_by_query', array( $this, 'astra_get_posts_by_query' ) );
+		add_action( 'wp_ajax_hfe_get_posts_by_query', array( $this, 'hfe_get_posts_by_query' ) );
 	}
 
 	/**
@@ -304,7 +304,10 @@ class Astra_Target_Rules_Fields {
 	 *
 	 * @since  1.0.0
 	 */
-	function astra_get_posts_by_query() {
+	function hfe_get_posts_by_query() {
+
+		check_ajax_referer( 'hfe-get-posts-by-query', 'nonce' );
+
 		$search_string = isset( $_POST['q'] ) ? sanitize_text_field( $_POST['q'] ) : '';
 		$data          = array();
 		$result        = array();
@@ -411,7 +414,7 @@ class Astra_Target_Rules_Fields {
 
 	/**
 	 * Return search results only by post title.
-	 * This is only run from astra_get_posts_by_query()
+	 * This is only run from hfe_get_posts_by_query()
 	 *
 	 * @param  (string)   $search   Search SQL for WHERE clause.
 	 * @param  (WP_Query) $wp_query The current WP_Query object.
@@ -628,6 +631,7 @@ class Astra_Target_Rules_Fields {
 			'searching'     => __( 'Searching…', 'header-footer-elementor' ),
 			'not_loader'    => __( 'The results could not be loaded.', 'header-footer-elementor' ),
 			'search'        => __( 'Search pages / post / categories', 'header-footer-elementor' ),
+			'ajax_nonce'    => wp_create_nonce( 'hfe-get-posts-by-query' ),
 		);
 		wp_localize_script( 'astra-select2', 'astRules', $localize_vars );
 	}

--- a/inc/lib/target-rule/target-rule.js
+++ b/inc/lib/target-rule/target-rule.js
@@ -15,7 +15,8 @@
 			      	return {
 			        	q: params.term, // search term
 				        page: params.page,
-				        action: 'astra_get_posts_by_query'
+						action: 'hfe_get_posts_by_query',
+						nonce: astRules.ajax_nonce
 			    	};
 				},
 				processResults: function (data) {


### PR DESCRIPTION
### Description
- When Astra Pro is active the action astra_get_posts_by_query loads twice
- First, it loads from Astra Pro and then HFE
- As this is a singleton class it executes every time from Astra Pro

### Screenshots
- https://share.getcloudapp.com/6qu2RzOv

### Types of changes
- Updated different action name from astra_get_posts_by_query to hfe_get_posts_by_query
- Verified nonce as well from AJAX action

### How has this been tested?
- With Astra Pro version (> 2.5.1)

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code has proper inline documentation 
- [x] I've included any necessary tests
- [x] I've included developer documentation 
- [ ] I've added proper labels to this pull request
