### PR TITLE
Improvement - Navigation Menu: Added SVG support to toggle and close icon.

### DIFF
--- a/inc/js/frontend.js
+++ b/inc/js/frontend.js
@@ -516,60 +516,61 @@
 
 	function _toggleClick( id ){
 
-		if ( $( '.elementor-element-' + id + ' .hfe-nav-menu__toggle i' ).parent().parent().hasClass( 'hfe-active-menu-full-width' ) ){
+		if ( $( '.elementor-element-' + id + ' .hfe-nav-menu__toggle' ).hasClass( 'hfe-active-menu-full-width' ) ){
 
-			$( '.elementor-element-' + id + ' .hfe-nav-menu__toggle i' ).parent().parent().next().css( 'left', '0' );
+			$( '.elementor-element-' + id + ' .hfe-nav-menu__toggle' ).next().css( 'left', '0' );
 
 			var width = $( '.elementor-element-' + id ).closest('.elementor-section').outerWidth();
-			var sec_pos = $( '.elementor-element-' + id ).closest('.elementor-section').offset().left - $( '.elementor-element-' + id + ' .hfe-nav-menu__toggle i' ).parent().parent().next().offset().left;
-			$( '.elementor-element-' + id + ' .hfe-nav-menu__toggle i' ).parent().parent().next().css( 'width', width + 'px' );
-			$( '.elementor-element-' + id + ' .hfe-nav-menu__toggle i' ).parent().parent().next().css( 'left', sec_pos + 'px' );
+			var sec_pos = $( '.elementor-element-' + id ).closest('.elementor-section').offset().left - $( '.elementor-element-' + id + ' .hfe-nav-menu__toggle' ).next().offset().left;
+			$( '.elementor-element-' + id + ' .hfe-nav-menu__toggle' ).next().css( 'width', width + 'px' );
+			$( '.elementor-element-' + id + ' .hfe-nav-menu__toggle' ).next().css( 'left', sec_pos + 'px' );
 		}
 
 		$( '.elementor-element-' + id + ' .hfe-nav-menu__toggle .hfe-nav-menu-icon' ).off( 'click keyup' ).on( 'click keyup', function( event ) {
 
-			var $this = $( this ).find( 'i' );
+			var $this = $( this );
+			var $selector = $this.next();
 
-			if ( $this.parent().parent().hasClass( 'hfe-active-menu' ) ) {
+			if ( $this.hasClass( 'hfe-active-menu' ) ) {
 
 				var layout = $( '.elementor-element-' + id + ' .hfe-nav-menu' ).data( 'layout' );
-				var full_width = $this.parent().parent().next().data( 'full-width' );
+				var full_width = $selector.data( 'full-width' );
 				var toggle_icon = $( '.elementor-element-' + id + ' nav' ).data( 'toggle-icon' );
 
-				$( '.elementor-element-' + id).find( '.hfe-nav-menu-icon i' ).attr( 'class', toggle_icon );
+				$( '.elementor-element-' + id).find( '.hfe-nav-menu-icon' ).html( toggle_icon );
 
-				$this.parent().parent().removeClass( 'hfe-active-menu' );
-				$this.parent().parent().attr( 'aria-expanded', 'false' );
+				$this.removeClass( 'hfe-active-menu' );
+				$this.attr( 'aria-expanded', 'false' );
 				
 				if ( 'yes' == full_width ){
 
-					$this.parent().parent().removeClass( 'hfe-active-menu-full-width' );
+					$this.removeClass( 'hfe-active-menu-full-width' );
 				
-					$this.parent().parent().next().css( 'width', 'auto' );
-					$this.parent().parent().next().css( 'left', '0' );
-					$this.parent().parent().next().css( 'z-index', '0' );
+					$selector.css( 'width', 'auto' );
+					$selector.css( 'left', '0' );
+					$selector.css( 'z-index', '0' );
 				}				
 			} else {
 
 				var layout = $( '.elementor-element-' + id + ' .hfe-nav-menu' ).data( 'layout' );
-				var full_width = $this.parent().parent().next().data( 'full-width' );
+				var full_width = $selector.data( 'full-width' );
 				var close_icon = $( '.elementor-element-' + id + ' nav' ).data( 'close-icon' );
 
-				$( '.elementor-element-' + id).find( '.hfe-nav-menu-icon i' ).attr( 'class', close_icon );
+				$( '.elementor-element-' + id).find( '.hfe-nav-menu-icon' ).html( close_icon );
 				
-				$this.parent().parent().addClass( 'hfe-active-menu' );
-				$this.parent().parent().attr( 'aria-expanded', 'true' );
+				$this.addClass( 'hfe-active-menu' );
+				$this.attr( 'aria-expanded', 'true' );
 
 				if ( 'yes' == full_width ){
 
-					$this.parent().parent().addClass( 'hfe-active-menu-full-width' );
+					$this.addClass( 'hfe-active-menu-full-width' );
 
 					var width = $( '.elementor-element-' + id ).closest('.elementor-section').outerWidth();
 					var sec_pos = $( '.elementor-element-' + id ).closest('.elementor-section').offset().left - $this.parent().parent().next().offset().left;
 				
-					$this.parent().parent().next().css( 'width', width + 'px' );
-					$this.parent().parent().next().css( 'left', sec_pos + 'px' );
-					$this.parent().parent().next().css( 'z-index', '9999' );
+					$selector.css( 'width', width + 'px' );
+					$selector.css( 'left', sec_pos + 'px' );
+					$selector.css( 'z-index', '9999' );
 				}
 			}
 

--- a/inc/widgets-css/frontend.css
+++ b/inc/widgets-css/frontend.css
@@ -308,6 +308,13 @@ div.hfe-nav-menu,
     border: 0 solid;
 }
 
+.hfe-nav-menu-icon svg {
+    width: 25px;
+    height: 25px;
+    line-height: 25px;
+    font-size: 25px;
+}
+
 .hfe-nav-menu-icon i:focus {
     outline: 0;
 }
@@ -933,7 +940,8 @@ div.hfe-nav-menu,
     transform: none;
 }
 
-.hfe-flyout-close {
+.hfe-flyout-close,
+.hfe-flyout-close svg {
     position: absolute;
     top: 0;
     right: 0;

--- a/inc/widgets-manager/widgets/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/class-navigation-menu.php
@@ -1758,6 +1758,43 @@ class Navigation_Menu extends Widget_Base {
 	}
 
 	/**
+	 * Get the menu and close icon HTML.
+	 *
+	 * @since x.x.x
+	 * @param array $settings Widget settings array.
+	 * @access public
+	 */
+	public function get_menu_close_icon( $settings ) {
+		$menu_icon     = '';
+		$close_icon    = '';
+		$icons         = array();
+		$icon_settings = array(
+			$settings['dropdown_icon'],
+			$settings['dropdown_close_icon'],
+		);
+
+		foreach ( $icon_settings as $icon ) {
+			if ( $this->is_elementor_updated() ) {
+				ob_start();
+				\Elementor\Icons_Manager::render_icon(
+					$icon,
+					array(
+						'aria-hidden' => 'true',
+						'tabindex'    => '0',
+					)
+				);
+				$menu_icon = ob_get_clean();
+			} else {
+				$menu_icon = '<i class="' . esc_attr( $icon ) . '" aria-hidden="true" tabindex="0"></i>';
+			}
+
+			array_push( $icons, $menu_icon );
+		}
+
+		return $icons;
+	}
+
+	/**
 	 * Render Nav Menu output on the frontend.
 	 *
 	 * Written in PHP and used to generate the final HTML.
@@ -1768,6 +1805,8 @@ class Navigation_Menu extends Widget_Base {
 	protected function render() {
 
 		$settings = $this->get_settings_for_display();
+		$menu_close_icons = array();
+		$menu_close_icons = $this->get_menu_close_icon( $settings );
 
 		$args = [
 			'echo'        => false,
@@ -1792,11 +1831,7 @@ class Navigation_Menu extends Widget_Base {
 			?>
 			<div class="hfe-nav-menu__toggle elementor-clickable hfe-flyout-trigger" tabindex="0">
 					<div class="hfe-nav-menu-icon">
-						<?php if ( $this->is_elementor_updated() ) { ?>
-							<i class="<?php echo esc_attr( $settings['dropdown_icon']['value'] ); ?>" aria-hidden="true" tabindex="0"></i>
-						<?php } else { ?>
-							<i class="<?php echo esc_attr( $settings['dropdown_icon'] ); ?>" aria-hidden="true" tabindex="0"></i>
-						<?php } ?>
+						<?php echo isset( $menu_close_icons[0] ) ? $menu_close_icons[0] : ''; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> 
 					</div>
 				</div>
 			<div <?php echo wp_kses_post( $this->get_render_attribute_string( 'hfe-flyout' ) ); ?> >
@@ -1806,11 +1841,7 @@ class Navigation_Menu extends Widget_Base {
 						<div class="hfe-flyout-content push">						
 							<nav <?php echo wp_kses_post( $this->get_render_attribute_string( 'hfe-nav-menu' ) ); ?>><?php echo $menu_html; ?></nav>
 							<div class="elementor-clickable hfe-flyout-close" tabindex="0">
-								<?php if ( $this->is_elementor_updated() ) { ?>
-									<i class="<?php echo esc_attr( $settings['dropdown_close_icon']['value'] ); ?>" aria-hidden="true"></i>
-								<?php } else { ?>
-									<i class="<?php echo esc_attr( $settings['dropdown_close_icon'] ); ?>" aria-hidden="true"></i>
-								<?php } ?>
+								<?php echo isset( $menu_close_icons[1] ) ? $menu_close_icons[1] : ''; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 							</div>
 						</div>
 					</div>
@@ -1865,9 +1896,9 @@ class Navigation_Menu extends Widget_Base {
 				]
 			);
 
-			$this->add_render_attribute( 'hfe-nav-menu', 'data-toggle-icon', $settings['dropdown_icon'] );
+			$this->add_render_attribute( 'hfe-nav-menu', 'data-toggle-icon', $menu_close_icons[0] );
 
-			$this->add_render_attribute( 'hfe-nav-menu', 'data-close-icon', $settings['dropdown_close_icon'] );
+			$this->add_render_attribute( 'hfe-nav-menu', 'data-close-icon', $menu_close_icons[1] );
 
 			$this->add_render_attribute( 'hfe-nav-menu', 'data-full-width', $settings['full_width_dropdown'] );
 
@@ -1875,14 +1906,7 @@ class Navigation_Menu extends Widget_Base {
 			<div <?php echo $this->get_render_attribute_string( 'hfe-main-menu' ); ?>>
 				<div class="hfe-nav-menu__toggle elementor-clickable">
 					<div class="hfe-nav-menu-icon">
-						<?php
-						if ( $this->is_elementor_updated() ) {
-							$dropdown_icon_value = isset( $settings['dropdown_icon']['value'] ) ? $settings['dropdown_icon']['value'] : '';
-							?>
-							<i class="<?php echo esc_attr( $dropdown_icon_value ); ?>" aria-hidden="true" tabindex="0"></i>
-						<?php } else { ?>
-							<i class="<?php echo esc_attr( $settings['dropdown_icon'] ); ?>" aria-hidden="true" tabindex="0"></i>
-						<?php } ?>
+						<?php echo isset( $menu_close_icons[0] ) ? $menu_close_icons[0] : ''; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					</div>
 				</div>
 				<nav <?php echo $this->get_render_attribute_string( 'hfe-nav-menu' ); ?>><?php echo $menu_html; ?></nav>              

--- a/inc/widgets-manager/widgets/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/class-navigation-menu.php
@@ -1524,7 +1524,7 @@ class Navigation_Menu extends Widget_Base {
 					],
 				],
 				'selectors' => [
-					'{{WRAPPER}} .hfe-nav-menu-icon' => 'font-size: {{SIZE}}{{UNIT}}',
+					'{{WRAPPER}} .hfe-nav-menu-icon'     => 'font-size: {{SIZE}}{{UNIT}}',
 					'{{WRAPPER}} .hfe-nav-menu-icon svg' => 'font-size: {{SIZE}}px;line-height: {{SIZE}}px;height: {{SIZE}}px;width: {{SIZE}}px;',
 				],
 				'separator' => 'before',
@@ -1566,7 +1566,7 @@ class Navigation_Menu extends Widget_Base {
 				'type'      => Controls_Manager::COLOR,
 				'default'   => '#7A7A7A',
 				'selectors' => [
-					'{{WRAPPER}} .hfe-flyout-close' => 'color: {{VALUE}}',
+					'{{WRAPPER}} .hfe-flyout-close'     => 'color: {{VALUE}}',
 					'{{WRAPPER}} .hfe-flyout-close svg' => 'fill: {{VALUE}}',
 
 				],
@@ -1774,21 +1774,21 @@ class Navigation_Menu extends Widget_Base {
 	public function get_menu_close_icon( $settings ) {
 		$menu_icon     = '';
 		$close_icon    = '';
-		$icons         = array();
-		$icon_settings = array(
+		$icons         = [];
+		$icon_settings = [
 			$settings['dropdown_icon'],
 			$settings['dropdown_close_icon'],
-		);
+		];
 
 		foreach ( $icon_settings as $icon ) {
 			if ( $this->is_elementor_updated() ) {
 				ob_start();
 				\Elementor\Icons_Manager::render_icon(
 					$icon,
-					array(
+					[
 						'aria-hidden' => 'true',
 						'tabindex'    => '0',
-					)
+					]
 				);
 				$menu_icon = ob_get_clean();
 			} else {
@@ -1811,8 +1811,8 @@ class Navigation_Menu extends Widget_Base {
 	 */
 	protected function render() {
 
-		$settings = $this->get_settings_for_display();
-		$menu_close_icons = array();
+		$settings         = $this->get_settings_for_display();
+		$menu_close_icons = [];
 		$menu_close_icons = $this->get_menu_close_icon( $settings );
 
 		$args = [

--- a/inc/widgets-manager/widgets/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/class-navigation-menu.php
@@ -1460,6 +1460,7 @@ class Navigation_Menu extends Widget_Base {
 				'type'      => Controls_Manager::COLOR,
 				'selectors' => [
 					'{{WRAPPER}} div.hfe-nav-menu-icon' => 'color: {{VALUE}}',
+					'{{WRAPPER}} div.hfe-nav-menu-icon svg' => 'fill: {{VALUE}}',
 				],
 			]
 		);
@@ -1491,6 +1492,8 @@ class Navigation_Menu extends Widget_Base {
 				'type'      => Controls_Manager::COLOR,
 				'selectors' => [
 					'{{WRAPPER}} div.hfe-nav-menu-icon:hover' => 'color: {{VALUE}}',
+					'{{WRAPPER}} div.hfe-nav-menu-icon:hover svg' => 'fill: {{VALUE}}',
+
 				],
 			]
 		);
@@ -1522,6 +1525,7 @@ class Navigation_Menu extends Widget_Base {
 				],
 				'selectors' => [
 					'{{WRAPPER}} .hfe-nav-menu-icon' => 'font-size: {{SIZE}}{{UNIT}}',
+					'{{WRAPPER}} .hfe-nav-menu-icon svg' => 'font-size: {{SIZE}}px;line-height: {{SIZE}}px;height: {{SIZE}}px;width: {{SIZE}}px;',
 				],
 				'separator' => 'before',
 			]
@@ -1563,6 +1567,8 @@ class Navigation_Menu extends Widget_Base {
 				'default'   => '#7A7A7A',
 				'selectors' => [
 					'{{WRAPPER}} .hfe-flyout-close' => 'color: {{VALUE}}',
+					'{{WRAPPER}} .hfe-flyout-close svg' => 'fill: {{VALUE}}',
+
 				],
 				'condition' => [
 					'layout' => 'flyout',
@@ -1582,7 +1588,8 @@ class Navigation_Menu extends Widget_Base {
 					],
 				],
 				'selectors' => [
-					'{{WRAPPER}} .hfe-flyout-close' => 'height: {{SIZE}}px; width: {{SIZE}}px; font-size: {{SIZE}}px; line-height: {{SIZE}}px;',
+					'{{WRAPPER}} .hfe-flyout-close,
+					{{WRAPPER}} .hfe-flyout-close svg' => 'height: {{SIZE}}px; width: {{SIZE}}px; font-size: {{SIZE}}px; line-height: {{SIZE}}px;',
 				],
 				'condition' => [
 					'layout' => 'flyout',

--- a/readme.txt
+++ b/readme.txt
@@ -138,6 +138,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 == Changelog ==
 
+= 1.5.2 =
+- Improvement: Navigation Menu - Added support to SVG for toggle and close icon.
+
 = 1.5.1 =
 - Fix: Retained GeneratePress theme's after header while using EHF header.
 - Fix: Target rule 'Specific Pages/Posts/Taxonomies etc' not working.

--- a/readme.txt
+++ b/readme.txt
@@ -139,6 +139,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 == Changelog ==
 
 = 1.5.2 =
+- Improvement: Compatibility with Polylang.
 - Improvement: Navigation Menu - Added support to SVG for toggle and close icon.
 - Fix: Cart - Missing wrapper class in the control selector.
 - Fix: Exclude EHF templates from query for target rules - Specific Pages / Posts / taxonomies etc.


### PR DESCRIPTION
### Description
Added SVG support to toggle and close icon.
https://trello.com/c/pyyDeiwY/53-nav-menu-svg-upload-support

### Types of changes
New feature (non-breaking change which adds functionality)

### How has this been tested?
With SVG 
With icons
Backward compatibility

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
