### PR TITLE
Fix: Navigation Menu - Added responsive support to flyout box width.

### DIFF
--- a/inc/js/frontend.js
+++ b/inc/js/frontend.js
@@ -256,7 +256,9 @@
 					'margin-left' : wrap_width,
 					'margin-right' : 'auto'
 				});
-			}		
+			}	
+
+			container.addClass( 'hfe-flyout-show' );	
 		} else {
 
 			$( 'body' ).css( 'margin-right', '0' );
@@ -271,6 +273,8 @@
 					'margin-right' : 'auto',
 				});
 			}
+
+			container.addClass( 'hfe-flyout-show' );
 		}		
 	}
 
@@ -301,7 +305,9 @@
 						width: '',
 					});
 				});
-			}			
+			}	
+
+			container.removeClass( 'hfe-flyout-show' );					
 		} else {
 			container.css( 'right', '-' + wrap_width );
 			
@@ -319,6 +325,7 @@
 					});
 				});
 			}
+			container.removeClass( 'hfe-flyout-show' );
 		}	
 	}
 

--- a/inc/js/frontend.js
+++ b/inc/js/frontend.js
@@ -235,9 +235,10 @@
 
 	function _openMenu( id ) {
 
+		var flyout_content = $( '#hfe-flyout-content-id-' + id );
 		var layout = $( '#hfe-flyout-content-id-' + id ).data( 'layout' );
 		var layout_type = $( '#hfe-flyout-content-id-' + id ).data( 'flyout-type' );
-		var wrap_width = $( '#hfe-flyout-content-id-' + id ).data( 'width' ) + 'px';
+		var wrap_width = flyout_content.width() + 'px';
 		var container = $( '.elementor-element-' + id + ' .hfe-flyout-container .hfe-side.hfe-flyout-' + layout );
 
 		$( '.elementor-element-' + id + ' .hfe-flyout-overlay' ).fadeIn( 100 );
@@ -275,8 +276,9 @@
 
 	function _closeMenu( id ) {
 
+		var flyout_content = $( '#hfe-flyout-content-id-' + id );
 		var layout    = $( '#hfe-flyout-content-id-' + id ).data( 'layout' );
-		var wrap_width = $( '#hfe-flyout-content-id-' + id ).data( 'width' ) + 'px';
+		var wrap_width = flyout_content.width() + 'px';
 		var layout_type = $( '#hfe-flyout-content-id-' + id ).data( 'flyout-type' );
 		var container = $( '.elementor-element-' + id + ' .hfe-flyout-container .hfe-side.hfe-flyout-' + layout );
 

--- a/inc/widgets-css/frontend.css
+++ b/inc/widgets-css/frontend.css
@@ -959,13 +959,17 @@ div.hfe-nav-menu,
 }
 
 .hfe-flyout-wrapper .hfe-side {
-    display: block;
+    display: none;
     position: fixed;
     z-index: 999999;
     padding: 0;
     margin: 0;
     -webkit-overflow-scrolling: touch;
     -webkit-backface-visibility: hidden;
+}
+
+.hfe-flyout-wrapper .hfe-side.hfe-flyout-show {
+    display: block;
 }
 
 .hfe-flyout-content.push {
@@ -979,17 +983,6 @@ div.hfe-nav-menu,
 /* ===========================================================
  *  Flyout Location
  * ======================================================== */
-
-.hfe-flyout-wrapper .hfe-side {
-    /* Allows iframes and google maps to display correctly while still being "hidden" */
-    display: block;
-    position: fixed;
-    z-index: 999999;
-    padding: 0;
-    margin: 0;
-    -webkit-overflow-scrolling: touch;
-    -webkit-backface-visibility: hidden;
-}
 
 .hfe-flyout-wrapper .hfe-side.hfe-flyout-right {
     top: 0;

--- a/inc/widgets-css/frontend.css
+++ b/inc/widgets-css/frontend.css
@@ -906,7 +906,6 @@ div.hfe-nav-menu,
     left: 0;
     right: 0;
     z-index: 999998;
-    background: url(../images/shade.png) repeat;
     background: rgba(0,0,0,.6);
     cursor: pointer;
     -webkit-backface-visibility: hidden;

--- a/inc/widgets-manager/widgets/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/class-navigation-menu.php
@@ -1802,7 +1802,7 @@ class Navigation_Menu extends Widget_Base {
 			<div <?php echo wp_kses_post( $this->get_render_attribute_string( 'hfe-flyout' ) ); ?> >
 				<div class="hfe-flyout-overlay elementor-clickable"></div>
 				<div class="hfe-flyout-container">
-					<div id="hfe-flyout-content-id-<?php echo esc_attr( $this->get_id() ); ?>" class="hfe-side hfe-flyout-<?php echo esc_attr( $settings['flyout_layout'] ); ?> hfe-flyout-open" data-width="<?php echo esc_attr( $settings['width_flyout_menu_item']['size'] ); ?>" data-layout="<?php echo wp_kses_post( $settings['flyout_layout'] ); ?>" data-flyout-type="<?php echo wp_kses_post( $settings['flyout_type'] ); ?>">
+					<div id="hfe-flyout-content-id-<?php echo esc_attr( $this->get_id() ); ?>" class="hfe-side hfe-flyout-<?php echo esc_attr( $settings['flyout_layout'] ); ?> hfe-flyout-open" data-layout="<?php echo wp_kses_post( $settings['flyout_layout'] ); ?>" data-flyout-type="<?php echo wp_kses_post( $settings['flyout_type'] ); ?>">
 						<div class="hfe-flyout-content push">						
 							<nav <?php echo wp_kses_post( $this->get_render_attribute_string( 'hfe-nav-menu' ) ); ?>><?php echo $menu_html; ?></nav>
 							<div class="elementor-clickable hfe-flyout-close" tabindex="0">

--- a/readme.txt
+++ b/readme.txt
@@ -138,6 +138,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 == Changelog ==
 
+= 1.5.2 =
+- Fix: Navigation Menu - Added responsive support to flyout box width.
+
 = 1.5.1 =
 - Fix: Retained GeneratePress theme's after header while using EHF header.
 - Fix: Target rule 'Specific Pages/Posts/Taxonomies etc' not working.


### PR DESCRIPTION
### Description
Fix: Navigation Menu - Added responsive support to flyout box width.

### Types of changes
Bugfix (non-breaking change which fixes an issue)

### How has this been tested?
- The issue with the flyout layout box width on responsive devices.
- https://trello.com/c/d6ph4gOP/63-nav-menu-add-responsive-support-to-flyout-box-width

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->