### PR TITLE
- Fix: Exclude EHF templates from query for target rules - Specific Pages / Posts / taxonomies etc.

### DIFF
--- a/inc/lib/target-rule/class-astra-target-rules-fields.php
+++ b/inc/lib/target-rule/class-astra-target-rules-fields.php
@@ -321,6 +321,8 @@ class Astra_Target_Rules_Fields {
 		$operator   = 'and'; // also supports 'or'.
 		$post_types = get_post_types( $args, $output, $operator );
 
+		unset( $post_types['elementor-hf'] ); //Exclude EHF templates.
+
 		$post_types['Posts'] = 'post';
 		$post_types['Pages'] = 'page';
 

--- a/readme.txt
+++ b/readme.txt
@@ -138,6 +138,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 == Changelog ==
 
+= 1.5.2 =
+- Fix: Exclude EHF templates from query for target rules - Specific Pages / Posts / taxonomies etc.
+
 = 1.5.1 =
 - Fix: Retained GeneratePress theme's after header while using EHF header.
 - Fix: Target rule 'Specific Pages/Posts/Taxonomies etc' not working.


### PR DESCRIPTION
### Description
- Fix: Exclude EHF templates from query for target rules - Specific Pages / Posts / taxonomies etc.
https://trello.com/c/6BnKsIxL/61-specific-post-target-rule

### Types of changes
Bug fix (non-breaking change which fixes an issue) 

### How has this been tested?
With EHF templates

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] I've added proper labels to this pull request <!-- if applicable -->
