### PR TITLE
Fix: Navigation Menu - Double link attributes issue with translation plugins.

### DIFF
--- a/inc/widgets-manager/widgets/class-menu-walker.php
+++ b/inc/widgets-manager/widgets/class-menu-walker.php
@@ -60,11 +60,11 @@ class Menu_Walker extends \Walker_Nav_Menu {
 		$attributes .= ! empty( $item->xfn ) ? ' rel="' . esc_attr( $item->xfn ) . $rel_xfn . '"' : '' . $rel_blank;
 		$attributes .= ! empty( $item->url ) ? ' href="' . esc_attr( $item->url ) . '"' : '';
 
-		$attributes .= apply_filters( 'hfe_nav_menu_attrs', array_filter( (array) $attributes ) );
+		$atts = apply_filters( 'hfe_nav_menu_attrs', $attributes );
 
 		$item_output  = $args->has_children ? '<div class="hfe-has-submenu-container">' : '';
 		$item_output .= $args->before;
-		$item_output .= '<a' . $attributes;
+		$item_output .= '<a' . $atts;
 		if ( 0 === $depth ) {
 			$item_output .= ' class = "hfe-menu-item"';
 		} else {

--- a/inc/widgets-manager/widgets/class-menu-walker.php
+++ b/inc/widgets-manager/widgets/class-menu-walker.php
@@ -59,8 +59,8 @@ class Menu_Walker extends \Walker_Nav_Menu {
 		$attributes .= ! empty( $item->target ) ? ' target="' . esc_attr( $item->target ) . '"' : '';
 		$attributes .= ! empty( $item->xfn ) ? ' rel="' . esc_attr( $item->xfn ) . $rel_xfn . '"' : '' . $rel_blank;
 		$attributes .= ! empty( $item->url ) ? ' href="' . esc_attr( $item->url ) . '"' : '';
-		
-		$attributes .= apply_filters( 'hfe_nav_menu_attrs', array_filter( (array)$attributes ) );
+
+		$attributes .= apply_filters( 'hfe_nav_menu_attrs', array_filter( (array) $attributes ) );
 
 		$item_output  = $args->has_children ? '<div class="hfe-has-submenu-container">' : '';
 		$item_output .= $args->before;

--- a/inc/widgets-manager/widgets/class-menu-walker.php
+++ b/inc/widgets-manager/widgets/class-menu-walker.php
@@ -60,7 +60,7 @@ class Menu_Walker extends \Walker_Nav_Menu {
 		$attributes .= ! empty( $item->xfn ) ? ' rel="' . esc_attr( $item->xfn ) . $rel_xfn . '"' : '' . $rel_blank;
 		$attributes .= ! empty( $item->url ) ? ' href="' . esc_attr( $item->url ) . '"' : '';
 
-		$attributes .= apply_filters( 'hfe_nav_menu_attrs', $attributes );
+		$attributes .= apply_filters( 'hfe_nav_menu_attrs', array_filter( $attributes ) );
 
 		$item_output  = $args->has_children ? '<div class="hfe-has-submenu-container">' : '';
 		$item_output .= $args->before;

--- a/inc/widgets-manager/widgets/class-menu-walker.php
+++ b/inc/widgets-manager/widgets/class-menu-walker.php
@@ -59,8 +59,8 @@ class Menu_Walker extends \Walker_Nav_Menu {
 		$attributes .= ! empty( $item->target ) ? ' target="' . esc_attr( $item->target ) . '"' : '';
 		$attributes .= ! empty( $item->xfn ) ? ' rel="' . esc_attr( $item->xfn ) . $rel_xfn . '"' : '' . $rel_blank;
 		$attributes .= ! empty( $item->url ) ? ' href="' . esc_attr( $item->url ) . '"' : '';
-
-		$attributes .= apply_filters( 'hfe_nav_menu_attrs', array_filter( $attributes ) );
+		
+		$attributes .= apply_filters( 'hfe_nav_menu_attrs', array_filter( (array)$attributes ) );
 
 		$item_output  = $args->has_children ? '<div class="hfe-has-submenu-container">' : '';
 		$item_output .= $args->before;

--- a/inc/widgets-manager/widgets/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/class-navigation-menu.php
@@ -1786,7 +1786,7 @@ class Navigation_Menu extends Widget_Base {
 	 */
 	public function handle_link_attrs( $atts ) {
 
-		$atts = 'itemprop="url"';
+		$atts .= ' itemprop="url"';
 		return $atts;
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -138,6 +138,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 == Changelog ==
 
+= 1.5.3 =
+- Fix: Navigation Menu - Double link attributes issue with translation plugins.
+
 = 1.5.2 =
 - Improvement: Compatibility with Polylang.
 - Improvement: Navigation Menu - Added 'SiteNavigationElement' schema support.

--- a/readme.txt
+++ b/readme.txt
@@ -139,11 +139,8 @@ This same applies when you are creating your Header/Footer using this plugin.
 == Changelog ==
 
 = 1.5.3 =
-<<<<<<< HEAD
 - Fix: Navigation Menu - Double link attributes issue with translation plugins.
-=======
 - Fix: Polylang plugin conflicting issue with target rules.
->>>>>>> 136a1e1e2e451940aa4015e1fcf0ddb9905496d9
 
 = 1.5.2 =
 - Improvement: Compatibility with Polylang.


### PR DESCRIPTION
### Description
Fix: Navigation Menu - Double link attributes issue with translation plugins.

### Types of changes
 Bugfix (non-breaking change which fixes an issue) 

### How has this been tested?
- Use TranslatePress Plugin
- Create a header with the Navigation menu widget.
- Set `Enable Schema`  switcher - Off
- Check on the frontend and translate the page into another language using a language switcher.
- The navigation menu should not break.
- Set `Enable Schema` - ON & follow above steps.
- https://trello.com/c/2Vjaqdn2/68-navigation-menu-issue-with-translation-plugins

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

