### PR TITLE
Fix: Navigation Menu - Fixed spacing issue when border-width is increased for expanded layout.

### DIFF
--- a/inc/widgets-css/frontend.css
+++ b/inc/widgets-css/frontend.css
@@ -387,6 +387,7 @@ div.hfe-nav-menu,
 .hfe-nav-menu__layout-expandible {
     visibility: hidden;
     opacity: 0; 
+    display:none;
 }
 
 .hfe-nav-menu__layout-expandible .sub-menu {
@@ -398,6 +399,7 @@ div.hfe-nav-menu,
     visibility: visible;
     opacity: 1; 
     height: auto;
+    display: block;
 }
 
 .hfe-active-menu.hfe-active-menu-full-width + .hfe-nav-menu__layout-expandible,

--- a/readme.txt
+++ b/readme.txt
@@ -137,6 +137,8 @@ This same applies when you are creating your Header/Footer using this plugin.
 5. Default widgets available with Elementor – Header, Footer & Blocks.
 
 == Changelog ==
+= Development Version =
+- Fix: Navigation Menu - Fixed spacing issue when border-width is increased for expanded layout.
 
 = 1.5.3 =
 - Fix: Polylang plugin conflicting issue with target rules.


### PR DESCRIPTION
### Description
Fixed spacing issue when border-width is increased for expanded layout.

### Types of changes
Bugfix (non-breaking change which fixes an issue) 

### How has this been tested?
- Steps to reproduce the issue - https://www.loom.com/share/3cb5db67216541cabde708545a199827
- Space should not get added if border width is increased for expanded layout.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
