### PR TITLE
Fix: Notice appears to install Elementor if Elementor is installed but not active.

### DIFF
--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -205,7 +205,7 @@ class Header_Footer_Elementor {
 
 			$plugin = 'elementor/elementor.php';
 
-			if ( _is_elementor_installed() ) {
+			if ( file_exists( WP_PLUGIN_DIR . '/elementor/elementor.php' ) ) {
 
 				$action_url   = wp_nonce_url( 'plugins.php?action=activate&amp;plugin=' . $plugin . '&amp;plugin_status=all&amp;paged=1&amp;s', 'activate-plugin_' . $plugin );
 				$button_label = __( 'Activate Elementor', 'header-footer-elementor' );
@@ -450,20 +450,4 @@ class Header_Footer_Elementor {
 		return self::$elementor_instance->frontend->get_builder_content_for_display( $id );
 	}
 
-}
-/**
- * Is elementor plugin installed.
- */
-if ( ! function_exists( '_is_elementor_installed' ) ) {
-
-	/**
-	 * Check if Elementor is installed
-	 *
-	 * @since 1.5.0
-	 *
-	 * @access public
-	 */
-	function _is_elementor_installed() {
-		return defined( 'ELEMENTOR_VERSION' ) ? true : false;
-	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -138,6 +138,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 == Changelog ==
 = Development Version =
+- Fix: Notice appears to install Elementor if Elementor is installed but not active.
 - Fix: Closed the HTML tag in footer in the global theme compatibility.
 - Fix: Navigation Menu - Fixed spacing issue when border-width is increased for expanded layout.
 - Fix: Navigation Menu - Fixed extra spacing if used in the footer.


### PR DESCRIPTION
### Description
The notice appears to install Elementor if it is not active.
Fixed by using file_exists()

### Types of changes
Bugfix (non-breaking change which fixes an issue) 

### How has this been tested?

- With Elementor installed but not active
- With Elementor not installed
- With Elementor installed and active

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] I've added proper labels to this pull request 
