### PR TITLE
Improvement: Navigation Menu - Added option to allow user to open a parent menu link on first click.

### DIFF
--- a/inc/js/frontend.js
+++ b/inc/js/frontend.js
@@ -336,82 +336,84 @@
 		$( '.elementor-element-' + id + ' div.hfe-has-submenu-container' ).off( 'click' ).on( 'click', function( event ) {
 
 			var $this = $( this );
-			
-		  	if( $this.hasClass( 'sub-menu-active' ) ) {
 
-		  		if( ! $this.next().hasClass( 'sub-menu-open' ) ) {
+			if( $( '.elementor-element-' + id ).hasClass( 'hfe-link-redirect-child' ) ) {
+				if( $this.hasClass( 'sub-menu-active' ) ) {
 
-		  			$this.find( 'a' ).attr( 'aria-expanded', 'false' );
+					if( ! $this.next().hasClass( 'sub-menu-open' ) ) {
 
-		  			if( 'horizontal' !== layout ){
+						$this.find( 'a' ).attr( 'aria-expanded', 'false' );
 
-						event.preventDefault();
+						if( 'horizontal' !== layout ){
 
-		  				$this.next().css( 'position', 'relative' );	
-					}else if ( 'horizontal' === layout && window.matchMedia( "( max-width: 767px )" ).matches && ($( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-tablet') || $( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-mobile'))) {
+							event.preventDefault();
+
+							$this.next().css( 'position', 'relative' );	
+						}else if ( 'horizontal' === layout && window.matchMedia( "( max-width: 767px )" ).matches && ($( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-tablet') || $( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-mobile'))) {
+							
+							event.preventDefault();
+
+							$this.next().css( 'position', 'relative' );	
+						}else if ( 'horizontal' === layout && window.matchMedia( "( max-width: 1024px )" ).matches && ( $( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-tablet') || $( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-mobile'))) {
+							
+							event.preventDefault();	
+
+							$this.next().css( 'position', 'relative' );	
+						}	
+					
+						$this.removeClass( 'sub-menu-active' );
+						$this.next().removeClass( 'sub-menu-open' );
+						$this.next().css( { 'visibility': 'hidden', 'opacity': '0', 'height': '0' } );
+						$this.next().css( { 'transition': 'none'} );										
+					}else{
+
+						$this.find( 'a' ).attr( 'aria-expanded', 'false' );
 						
-						event.preventDefault();
+						$this.removeClass( 'sub-menu-active' );
+						$this.next().removeClass( 'sub-menu-open' );
+						$this.next().css( { 'visibility': 'hidden', 'opacity': '0', 'height': '0' } );
+						$this.next().css( { 'transition': 'none'} );	
+													
+						if ( 'horizontal' !== layout ){
 
-		  				$this.next().css( 'position', 'relative' );	
-					}else if ( 'horizontal' === layout && window.matchMedia( "( max-width: 1024px )" ).matches && ( $( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-tablet') || $( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-mobile'))) {
-						
-						event.preventDefault();	
+							$this.next().css( 'position', 'relative' );
+						} else if ( 'horizontal' === layout && window.matchMedia( "( max-width: 767px )" ).matches && ($( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-tablet') || $( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-mobile'))) {
+							
+							$this.next().css( 'position', 'relative' );	
+							
+						} else if ( 'horizontal' === layout && window.matchMedia( "( max-width: 1024px )" ).matches && ( $( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-tablet') || $( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-mobile'))) {
+							
+							$this.next().css( 'position', 'absolute' );				
+						}	  								
+					}		  											
+				}else {
 
-		  				$this.next().css( 'position', 'relative' );	
-					}	
-	  			
-					$this.removeClass( 'sub-menu-active' );
-					$this.next().removeClass( 'sub-menu-open' );
-					$this.next().css( { 'visibility': 'hidden', 'opacity': '0', 'height': '0' } );
-					$this.next().css( { 'transition': 'none'} );										
-		  		}else{
+						$this.find( 'a' ).attr( 'aria-expanded', 'true' );
+						if ( 'horizontal' !== layout ) {
+							
+							event.preventDefault();
+							$this.next().css( 'position', 'relative');			
+						} else if ( 'horizontal' === layout && window.matchMedia( "( max-width: 767px )" ).matches && ($( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-tablet') || $( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-mobile'))) {
+							
+							event.preventDefault();
+							$this.next().css( 'position', 'relative');		  					
+						} else if ( 'horizontal' === layout && window.matchMedia( "( max-width: 1024px )" ).matches ) {
+							event.preventDefault();
 
-		  			$this.find( 'a' ).attr( 'aria-expanded', 'false' );
-		  			
-		  			$this.removeClass( 'sub-menu-active' );
-					$this.next().removeClass( 'sub-menu-open' );
-					$this.next().css( { 'visibility': 'hidden', 'opacity': '0', 'height': '0' } );
-					$this.next().css( { 'transition': 'none'} );	
-						  			  			
-					if ( 'horizontal' !== layout ){
+							if ( $( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-tablet') ) {
 
-						$this.next().css( 'position', 'relative' );
-					} else if ( 'horizontal' === layout && window.matchMedia( "( max-width: 767px )" ).matches && ($( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-tablet') || $( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-mobile'))) {
-						
-						$this.next().css( 'position', 'relative' );	
-						
-					} else if ( 'horizontal' === layout && window.matchMedia( "( max-width: 1024px )" ).matches && ( $( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-tablet') || $( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-mobile'))) {
-						
-						$this.next().css( 'position', 'absolute' );				
-					}	  								
-		  		}		  											
-			}else {
-
-					$this.find( 'a' ).attr( 'aria-expanded', 'true' );
-					if ( 'horizontal' !== layout ) {
-						
-						event.preventDefault();
-			  			$this.next().css( 'position', 'relative');			
-					} else if ( 'horizontal' === layout && window.matchMedia( "( max-width: 767px )" ).matches && ($( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-tablet') || $( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-mobile'))) {
-						
-						event.preventDefault();
-	  					$this.next().css( 'position', 'relative');		  					
-					} else if ( 'horizontal' === layout && window.matchMedia( "( max-width: 1024px )" ).matches ) {
-						event.preventDefault();
-
-	  					if ( $( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-tablet') ) {
-
-	  						$this.next().css( 'position', 'relative');	
-	  					} else if ( $( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-mobile') || $( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-none') ) {
-	  						
-	  						$this.next().css( 'position', 'absolute');	
-	  					}
-	  				}	
-	  					
-				$this.addClass( 'sub-menu-active' );
-				$this.next().addClass( 'sub-menu-open' );	
-				$this.next().css( { 'visibility': 'visible', 'opacity': '1', 'height': 'auto' } );
-				$this.next().css( { 'transition': '0.3s ease'} );								
+								$this.next().css( 'position', 'relative');	
+							} else if ( $( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-mobile') || $( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-none') ) {
+								
+								$this.next().css( 'position', 'absolute');	
+							}
+						}	
+							
+					$this.addClass( 'sub-menu-active' );
+					$this.next().addClass( 'sub-menu-open' );	
+					$this.next().css( { 'visibility': 'visible', 'opacity': '1', 'height': 'auto' } );
+					$this.next().css( { 'transition': '0.3s ease'} );								
+				}
 			}
 		});
 
@@ -448,7 +450,7 @@
 
 				$this.parent().parent().addClass( 'menu-active' );
 
-				$this.parent().parent().next().css( { 'visibility': 'visible', 'opacity': '1', 'height': 'auto' } );
+				$this.parent().parent().next().css( { 'visibility': 'visible', 'opacity': '1', 'height': 'auto', 'display':'block' } );
 
 				if ( 'horizontal' !== layout ) {
 						

--- a/inc/widgets-css/frontend.css
+++ b/inc/widgets-css/frontend.css
@@ -280,13 +280,13 @@ div.hfe-nav-menu,
     display: none; 
 }
 
-.hfe-submenu-icon-arrow .hfe-nav-menu .parent-has-child .sub-menu-active .sub-arrow i:before {
+.hfe-submenu-icon-arrow .hfe-nav-menu .parent-has-child .sub-menu-active .sub-arrow i:before,.hfe-link-redirect-self_link.hfe-submenu-icon-arrow .hfe-nav-menu .parent-has-child .menu-active .sub-arrow i:before {
     content: ''; 
 }
-.hfe-submenu-icon-plus .hfe-nav-menu .parent-has-child .sub-menu-active .sub-arrow i:before {
+.hfe-submenu-icon-plus .hfe-nav-menu .parent-has-child .sub-menu-active .sub-arrow i:before, .hfe-link-redirect-self_link.hfe-submenu-icon-plus .hfe-nav-menu .parent-has-child .menu-active .sub-arrow i:before {
     content: '-'; 
 }
-.hfe-submenu-icon-classic .hfe-nav-menu .parent-has-child .sub-menu-active .sub-arrow i:before {
+.hfe-submenu-icon-classic .hfe-nav-menu .parent-has-child .sub-menu-active .sub-arrow i:before, .hfe-link-redirect-self_link.hfe-submenu-icon-classic .hfe-nav-menu .parent-has-child .menu-active .sub-arrow i:before {
     content: ''; 
 }
 

--- a/inc/widgets-manager/widgets/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/class-navigation-menu.php
@@ -439,6 +439,21 @@ class Navigation_Menu extends Widget_Base {
 			);
 
 			$this->add_control(
+				'link_redirect',
+				array(
+					'label'        => __( 'On Menu Click', 'header-footer-elementor' ),
+					'type'         => Controls_Manager::SELECT,
+					'default'      => 'child',
+					'description'  => __( 'For Horizontal layout, this will affect on the selected breakpoint', 'header-footer-elementor' ),
+					'options'      => array(
+						'child'     => __( 'Open Child', 'header-footer-elementor' ),
+						'self_link' => __( 'Redirect To Self Link', 'uael' ),
+					),
+					'prefix_class' => 'hfe-link-redirect-',
+				)
+			);
+			
+			$this->add_control(
 				'heading_responsive',
 				[
 					'type'      => Controls_Manager::HEADING,

--- a/inc/widgets-manager/widgets/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/class-navigation-menu.php
@@ -441,12 +441,12 @@ class Navigation_Menu extends Widget_Base {
 			$this->add_control(
 				'link_redirect',
 				array(
-					'label'        => __( 'On Menu Click', 'header-footer-elementor' ),
+					'label'        => __( 'Action On Menu Click', 'header-footer-elementor' ),
 					'type'         => Controls_Manager::SELECT,
 					'default'      => 'child',
 					'description'  => __( 'For Horizontal layout, this will affect on the selected breakpoint', 'header-footer-elementor' ),
 					'options'      => array(
-						'child'     => __( 'Open Child', 'header-footer-elementor' ),
+						'child'     => __( 'Open Submenu', 'header-footer-elementor' ),
 						'self_link' => __( 'Redirect To Self Link', 'uael' ),
 					),
 					'prefix_class' => 'hfe-link-redirect-',

--- a/readme.txt
+++ b/readme.txt
@@ -139,6 +139,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 == Changelog ==
 = 1.5.4 =
 - Improvement: Improved compatibility with Astra theme.
+- Improvement: Navigation Menu - Added option to allow user to open a parent menu link on first click.
 - Fix: Closed the HTML tag in footer in the global theme compatibility.
 - Fix: Notice appears to install Elementor if Elementor is installed but not active.
 - Fix: Navigation Menu - Fixed spacing issue when border-width is increased for 'Expanded' layout.


### PR DESCRIPTION
### Description
Added option to allow the user to open a parent menu link on the first click.

### Types of changes
 New feature (non-breaking change which adds functionality)

### How has this been tested?
* Check newly added option working fine.
* Check with all layout expect horizontal.
* Expected output - On the selection of `self-link` allows the user to open a self-link on the first click of a parent and only on the click of icon submenu should get open.
* Also check the open-close(in case of submenu) icon case.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
