### PR TITLE
Fix: Navigation Menu - Alignment option not working if the last menu item is a button.

### DIFF
--- a/inc/widgets-css/frontend.css
+++ b/inc/widgets-css/frontend.css
@@ -142,13 +142,13 @@ div.hfe-nav-menu,
           -webkit-justify-content: flex-end;
           -moz-box-pack: end;
           justify-content: flex-end; }
-.hfe-nav-menu__align-right .hfe-nav-menu__layout-vertical li.elementor-button-wrapper{
+.hfe-nav-menu__align-right .hfe-nav-menu__layout-vertical li .elementor-button-wrapper{
     text-align: right;
 }
-.hfe-nav-menu__align-left .hfe-nav-menu__layout-vertical li.elementor-button-wrapper{
+.hfe-nav-menu__align-left .hfe-nav-menu__layout-vertical li .elementor-button-wrapper{
     text-align: left;
 }
-.hfe-nav-menu__align-center .hfe-nav-menu__layout-vertical li.elementor-button-wrapper{
+.hfe-nav-menu__align-center .hfe-nav-menu__layout-vertical li .elementor-button-wrapper{
     text-align: center;
 }
 .hfe-nav-menu__align-left .hfe-nav-menu {

--- a/inc/widgets-manager/widgets/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/class-navigation-menu.php
@@ -399,8 +399,8 @@ class Navigation_Menu extends Widget_Base {
 					],
 					'selectors'    => [
 						'{{WRAPPER}} li.menu-item a' => 'justify-content: {{VALUE}};',
-						'{{WRAPPER}} li.elementor-button-wrapper' => 'text-align: {{VALUE}};',
-						'{{WRAPPER}}.hfe-menu-item-flex-end li.elementor-button-wrapper' => 'text-align: right;',
+						'{{WRAPPER}} li .elementor-button-wrapper' => 'text-align: {{VALUE}};',
+						'{{WRAPPER}}.hfe-menu-item-flex-end li .elementor-button-wrapper' => 'text-align: right;',
 					],
 					'prefix_class' => 'hfe-menu-item-',
 				]

--- a/readme.txt
+++ b/readme.txt
@@ -144,6 +144,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 - Fix: Notice appears to install Elementor if Elementor is installed but not active.
 - Fix: Navigation Menu - Fixed spacing issue when border-width is increased for 'Expanded' layout.
 - Fix: Navigation Menu - Fixed extra spacing if used in the footer.
+- Fix: Navigation Menu - Alignment option not working if the last menu item is a button.
 
 = 1.5.3 =
 - Fix: Polylang plugin conflicting issue with target rules.

--- a/readme.txt
+++ b/readme.txt
@@ -144,7 +144,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 - Fix: Notice appears to install Elementor if Elementor is installed but not active.
 - Fix: Navigation Menu - Fixed spacing issue when border-width is increased for 'Expanded' layout.
 - Fix: Navigation Menu - Fixed extra spacing if used in the footer.
-- Fix: Navigation Menu - Alignment option not working if the last menu item is a button.
+- Fix: Navigation Menu - Alignment option not working if the last menu item is set as 'Button'.
 
 = 1.5.3 =
 - Fix: Polylang plugin conflicting issue with target rules.


### PR DESCRIPTION
### Description
Alignment option not working if the last menu item is a button.

### Types of changes
Bugfix (non-breaking change which fixes an issue)

### How has this been tested?
- Check Vertical and Flyout layout.
- Check `Menu Item Align` control for Flyout layout and `Alignment` control for Vertical layout.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
