### PR TITLE
Fix: Added ALT attribute to the widget containing image.

### DIFF
--- a/inc/widgets-manager/widgets/class-retina.php
+++ b/inc/widgets-manager/widgets/class-retina.php
@@ -798,7 +798,7 @@ class Retina extends Widget_Base {
 			?>
 				<div class="hfe-retina-image-set">
 					<div class="hfe-retina-image-container">
-						<img class="hfe-retina-img <?php echo $class_animation; ?>"  src="<?php echo $image_url; ?>" srcset="<?php echo $image_url . ' 1x' . ',' . $retina_image_url . ' 2x'; ?>"/>
+						<img class="hfe-retina-img <?php echo $class_animation; ?>"  src="<?php echo $image_url; ?>" alt="<?php echo esc_attr( Control_Media::get_image_alt( $settings['retina_image'] ) ); ?>" srcset="<?php echo $image_url . ' 1x' . ',' . $retina_image_url . ' 2x'; ?>"/>
 					</div>
 				</div>
 			<?php if ( $link ) : ?>

--- a/inc/widgets-manager/widgets/class-site-logo.php
+++ b/inc/widgets-manager/widgets/class-site-logo.php
@@ -827,7 +827,7 @@ class Site_Logo extends Widget_Base {
 		?>
 			<div class="hfe-site-logo-set">           
 				<div class="hfe-site-logo-container">
-					<img class="hfe-site-logo-img <?php echo esc_attr( $class_animation ); ?>"  src="<?php echo esc_url( $image_url ); ?>"/>
+					<img class="hfe-site-logo-img <?php echo esc_attr( $class_animation ); ?>"  src="<?php echo esc_url( $image_url ); ?>" alt="<?php echo esc_attr( Control_Media::get_image_alt( $settings['custom_image'] ) ); ?>"/>
 				</div>
 			</div>
 		<?php if ( $link ) : ?>

--- a/readme.txt
+++ b/readme.txt
@@ -140,6 +140,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 = 1.5.4 =
 - Improvement: Improved compatibility with Astra theme.
 - Improvement: Navigation Menu - Added option to toggle menu item.
+- Fix: Added ALT attribute to the widget containing image.
 - Fix: Closed the HTML tag in footer in the global theme compatibility.
 - Fix: Notice appears to install Elementor if Elementor is installed but not active.
 - Fix: Navigation Menu - Fixed spacing issue when border-width is increased for 'Expanded' layout.


### PR DESCRIPTION
### Description
Fix: Added ALT attribute to the widget containing the image.

### Types of changes
 Bugfix (non-breaking change which fixes an issue) 

### How has this been tested?
-  Added ALT attribute support to the Retina Image and Site Logo widget.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
